### PR TITLE
fix(vm): prevent potential overflow in memory bounds checks

### DIFF
--- a/src/vm/memory.rs
+++ b/src/vm/memory.rs
@@ -83,9 +83,12 @@ impl GlobalMemory {
     /// If this operation accesses out of bounds linear memory.
     pub fn read(&self, offset: usize, buffer: &mut [u8]) -> Result<(), TrapCode> {
         let len_buffer = buffer.len();
+        let end = offset
+            .checked_add(len_buffer)
+            .ok_or(TrapCode::MemoryOutOfBounds)?;
         let slice = self
             .data()
-            .get(offset..(offset + len_buffer))
+            .get(offset..end)
             .ok_or(TrapCode::MemoryOutOfBounds)?;
         buffer.copy_from_slice(slice);
         Ok(())
@@ -99,9 +102,12 @@ impl GlobalMemory {
     /// If this operation accesses out of bounds linear memory.
     pub fn write(&mut self, offset: usize, buffer: &[u8]) -> Result<(), TrapCode> {
         let len_buffer = buffer.len();
+        let end = offset
+            .checked_add(len_buffer)
+            .ok_or(TrapCode::MemoryOutOfBounds)?;
         let slice = self
             .data_mut()
-            .get_mut(offset..(offset + len_buffer))
+            .get_mut(offset..end)
             .ok_or(TrapCode::MemoryOutOfBounds)?;
         slice.copy_from_slice(buffer);
         Ok(())


### PR DESCRIPTION
Prevent potential usize overflow when computing memory access ranges. Use checked_add for offset + len to ensure bounds checks remain correct and return MemoryOutOfBounds on overflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced memory bounds checking in read and write operations to ensure proper range validation and prevent potential overflow issues during memory access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->