### PR TITLE
fix: update wasmtime with enforced disabled opcodes rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ dependencies = [
 [[package]]
 name = "cranelift-assembler-x64"
 version = "0.128.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
@@ -258,7 +258,7 @@ dependencies = [
 [[package]]
 name = "cranelift-assembler-x64-meta"
 version = "0.128.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "cranelift-srcgen",
 ]
@@ -266,7 +266,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.128.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "cranelift-entity",
 ]
@@ -274,7 +274,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bitset"
 version = "0.128.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "serde",
  "serde_derive",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.128.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.128.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -321,12 +321,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.128.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 
 [[package]]
 name = "cranelift-control"
 version = "0.128.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "arbitrary",
 ]
@@ -334,7 +334,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.128.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -344,7 +344,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.128.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -355,12 +355,12 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.128.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 
 [[package]]
 name = "cranelift-native"
 version = "0.128.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -370,7 +370,7 @@ dependencies = [
 [[package]]
 name = "cranelift-srcgen"
 version = "0.128.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 
 [[package]]
 name = "crc32fast"
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "pulley-interpreter"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -1097,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "pulley-macros"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1842,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1899,7 +1899,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -1926,7 +1926,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-cache"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "base64",
  "directories-next",
@@ -1945,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-component-macro"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1959,12 +1959,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-component-util"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-fiber"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2005,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-debug"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "cc",
  "object",
@@ -2016,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-math"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "libm",
 ]
@@ -2035,12 +2035,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-slab"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2062,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-winch"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "cranelift-codegen",
  "gimli",
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2143,7 +2143,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winch-codegen"
 version = "41.0.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#62997e1964a820009ece0e19d4e3a918b47a4107"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=v41-patched#b0d3fff81af05afb89f748c602f4e2bf06a4c612"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ criterion = { version = "0.7.0", default-features = false, features = [] }
 fib-example = { path = "examples/fib" }
 
 [features]
-default = ["std", "wasmtime", "disable-fpu"]
+default = ["std", "wasmtime"]
 std = [
     "bytes/std",
     "bincode/std",
@@ -55,7 +55,6 @@ std = [
     "bitvec/std",
     "wasmtime?/std",
 ]
-disable-fpu = ["wasmtime/disable-fpu"]
 serde = [
     "dep:serde", "serde/derive"
 ]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ make test
 
 `Cargo.toml` defines the runtime surface via features. Important points:
 
-- default enables `std`, `wasmtime`, `disable-fpu`
+- default enables `std`, `wasmtime`
 - `fpu` exists as a feature-gated surface in code
 - FPU opcodes are currently not treated as production-facing opcode surface in docs (kept mainly for testsuite/internal
   compatibility)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,27 +15,27 @@ Wasm binary
 ## Major subsystems
 
 - **Compiler** (`src/compiler/**`)
-  - parses/validates wasm
-  - rewrites to rWASM-oriented instruction stream
-  - builds module metadata (func/table/data/global sections)
+    - parses/validates wasm
+    - rewrites to rWASM-oriented instruction stream
+    - builds module metadata (func/table/data/global sections)
 
 - **Module model** (`src/module/**`)
-  - serialized representation consumed by the runtime
-  - contains compiled funcs, signatures, globals, data/element segments, etc.
+    - serialized representation consumed by the runtime
+    - contains compiled funcs, signatures, globals, data/element segments, etc.
 
 - **Instruction set** (`src/types/opcode.rs`)
-  - defines opcode enum and instruction categories
-  - includes optional FPU opcodes behind `fpu` feature
+    - defines opcode enum and instruction categories
+    - includes optional FPU opcodes behind `fpu` feature
 
 - **Runtime VM** (`src/vm/**`)
-  - stack machine execution engine
-  - memory/table/global handling
-  - trap model + host import linkage
-  - optional tracing support
+    - stack machine execution engine
+    - memory/table/global handling
+    - trap model + host import linkage
+    - optional tracing support
 
 - **Execution strategy abstraction** (`src/strategy/**`)
-  - `Rwasm` strategy (native engine)
-  - optional `Wasmtime` strategy for compatibility/comparison
+    - `Rwasm` strategy (native engine)
+    - optional `Wasmtime` strategy for compatibility/comparison
 
 ## Design goals
 
@@ -49,10 +49,9 @@ Wasm binary
 
 Current cargo features (`Cargo.toml`):
 
-- `default = ["std", "wasmtime", "disable-fpu"]`
+- `default = ["std", "wasmtime"]`
 - `std`: std support for crate/runtime dependencies
 - `wasmtime`: enables wasmtime-backed strategy/execution
-- `disable-fpu`: configures wasmtime dependency with disabled FPU support
 - `fpu`: enables floating-point opcode/runtime surface in rWASM VM
 - `serde`: serde support for selected types
 - `tracing`: tracing-related model support (depends on `serde`)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `disable-fpu` feature flag configuration. Floating-point unit support is now always enabled by default.

* **Documentation**
  * Updated README and architecture documentation to reflect changes to default feature configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->