### PR TITLE
fuzz: align fuel parity by disabling params/locals metering in differential

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -14,6 +14,9 @@ For each generated module/export invocation, the harness compares:
 Fuel is initialized to the same `FUEL_LIMIT` on both sides.
 If consumed fuel differs, the target fails.
 
+To keep fuel comparison meaningful, rwasm compilation in this harness disables
+`consume_fuel_for_params_and_locals`, aligning with wasmtime's instruction-centric fuel behavior.
+
 ---
 
 ## Why some binaries are excluded

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -461,6 +461,10 @@ fn run_rwasm_one(
         .with_entrypoint_name(export.into())
         .with_allow_malformed_entrypoint_func_type(true)
         .with_allow_start_section(true)
+        // Keep fuel semantics aligned with wasmtime's instruction-centric consume_fuel mode.
+        // If this is true, rwasm additionally charges for params/locals setup, which can create
+        // deterministic +1 deltas that are harness artifacts rather than execution mismatches.
+        .with_consume_fuel_for_params_and_locals(false)
         .with_consume_fuel(true);
 
     let (module, _) = match RwasmModule::compile(config, wasm) {


### PR DESCRIPTION
## Summary
Fix differential fuzz false-positive fuel mismatches caused by rwasm-only params/locals metering.

### Problem
Fuzzer reported fuel diffs like:

```
rwasm_consumed=2
wasmtime_consumed=1
```

for otherwise matching execution/results.

Root cause: the differential harness compiled rwasm with `consume_fuel_for_params_and_locals = true`, while wasmtime fuel accounting is instruction-centric for this setup.
That creates deterministic +1 style harness deltas unrelated to semantic execution differences.

### Fix
In `run_rwasm_one`, set:

- `.with_consume_fuel_for_params_and_locals(false)`
- keep `.with_consume_fuel(true)`

This aligns metering semantics used for strict fuel parity checks.

Also documented this explicitly in `fuzz/README.md`.

## Validation
- Replayed provided failing artifact (`7QUFAAAAAP8=`) -> no fuel panic
- `cargo +nightly fuzz run differential -- -runs=1000` passes
- `cargo check --manifest-path fuzz/Cargo.toml` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified fuel consumption behavior documentation in the differential fuzzing harness to explain alignment with instruction-centric fuel semantics.

* **Tests**
  * Updated fuzzing harness compilation configuration to align fuel consumption behavior, ensuring consistent fuel accounting across test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->