### PR TITLE
fuzz: fix fuel parity with call-scoped reset and delta comparison

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -14,7 +14,8 @@ For each generated module/export invocation, the harness compares:
 Memory comparison is done directly on exported memory views.
 For compatibility with reserved-memory implementation differences, trailing all-zero extension bytes are treated as equivalent.
 
-Fuel is initialized to the same `FUEL_LIMIT` on both sides.
+Fuel is reset to the same `FUEL_LIMIT` **before each compared invocation** on both sides.
+The harness compares per-call consumed fuel deltas.
 If consumed fuel differs, the target fails.
 
 ---

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -331,10 +331,7 @@ fn differential_rwasm_vs_wasmtime(
 
     match (lhs_results, rhs_results) {
         // LHS ok, RHS ok: compare return values and then compare exported state.
-        (
-            Ok((lhs_vals, lhs_store, lhs_fuel_remaining)),
-            Ok(Some((rhs_vals, rhs_fuel_remaining))),
-        ) => {
+        (Ok((lhs_vals, lhs_store, lhs_fuel_consumed)), Ok(Some((rhs_vals, rhs_fuel_consumed)))) => {
             if lhs_vals != rhs_vals {
                 panic!(
                     "diff results: export={name} args={args:?} result_tys={result_tys:?}\n\
@@ -343,13 +340,11 @@ fn differential_rwasm_vs_wasmtime(
                 );
             }
 
-            let lhs_consumed = FUEL_LIMIT.saturating_sub(lhs_fuel_remaining);
-            let rhs_consumed = FUEL_LIMIT.saturating_sub(rhs_fuel_remaining);
-            if lhs_consumed != rhs_consumed {
+            if lhs_fuel_consumed != rhs_fuel_consumed {
                 panic!(
                     "diff fuel: export={name} args={args:?} result_tys={result_tys:?}\n\
-                     rwasm_remaining={lhs_fuel_remaining} rwasm_consumed={lhs_consumed}\n\
-                     wasmtime_remaining={rhs_fuel_remaining} wasmtime_consumed={rhs_consumed}\n"
+                     rwasm_consumed={lhs_fuel_consumed}\n\
+                     wasmtime_consumed={rhs_fuel_consumed}\n"
                 );
             }
 
@@ -406,6 +401,7 @@ fn run_rwasm_one(
     let engine = ExecutionEngine::default();
     let mut store = RwasmStore::<()>::default();
     store.reset_fuel(FUEL_LIMIT);
+    let fuel_before = store.remaining_fuel().unwrap_or(0);
 
     let fallback_funcref_idx = export_map.exported_funcs.get(export).copied();
     let params: Vec<Value> = match args
@@ -430,8 +426,9 @@ fn run_rwasm_one(
         .collect::<Option<Vec<_>>>()
         .ok_or(TrapCode::IllegalOpcode)?;
 
-    let fuel_remaining = store.remaining_fuel().unwrap_or(0);
-    Ok(Some((vals, store, fuel_remaining)))
+    let fuel_after = store.remaining_fuel().unwrap_or(0);
+    let fuel_consumed = fuel_before.saturating_sub(fuel_after);
+    Ok(Some((vals, store, fuel_consumed)))
 }
 
 /// Creates a Wasmtime store, with signal-based traps disabled on macOS.
@@ -672,6 +669,10 @@ impl RawWasmtimeInstance {
     fn new(mut store: Store<()>, module: Module) -> anyhow::Result<Self> {
         let instance = Instance::new(&mut store, &module, &[])
             .context("unable to instantiate module in wasmtime")?;
+        // Keep differential fuel accounting call-scoped (exclude instantiation/start side costs).
+        store
+            .set_fuel(FUEL_LIMIT)
+            .map_err(|e| anyhow::anyhow!("failed to reset wasmtime fuel after instantiate: {e}"))?;
         Ok(Self { store, instance })
     }
 
@@ -733,6 +734,14 @@ impl RawWasmtimeInstance {
         arguments: &[DiffValue],
         _results: &[DiffValueType],
     ) -> anyhow::Result<Option<(Vec<DiffValue>, u64)>> {
+        self.store
+            .set_fuel(FUEL_LIMIT)
+            .map_err(|e| anyhow::anyhow!("failed to reset wasmtime fuel: {e}"))?;
+        let fuel_before = self
+            .store
+            .get_fuel()
+            .map_err(|e| anyhow::anyhow!("failed to read wasmtime fuel: {e}"))?;
+
         let function = self
             .instance
             .get_func(&mut self.store, function_name)
@@ -756,12 +765,13 @@ impl RawWasmtimeInstance {
             .collect::<Option<Vec<_>>>()
             .ok_or_else(|| anyhow::anyhow!("unsupported result type"))?;
 
-        let remaining_fuel = self
+        let fuel_after = self
             .store
             .get_fuel()
             .map_err(|e| anyhow::anyhow!("failed to read wasmtime fuel: {e}"))?;
+        let fuel_consumed = fuel_before.saturating_sub(fuel_after);
 
-        Ok(Some((results, remaining_fuel)))
+        Ok(Some((results, fuel_consumed)))
     }
 
     fn get_global(&mut self, name: &str, _ty: DiffValueType) -> Option<DiffValue> {


### PR DESCRIPTION
## Summary
Fix differential fuzz fuel mismatches by switching to **call-scoped fuel accounting** instead of comparing against a global remaining-fuel assumption.

## Problem
Even with the same `FUEL_LIMIT`, comparing `FUEL_LIMIT - remaining` can drift due to fuel consumed outside the exact function call window (e.g. instantiation/start/setup timing differences).

This produced intermittent false-positive fuel diffs.

## Changes

1. Reset wasmtime fuel at call boundary:
   - in `RawWasmtimeInstance::new`: reset after instantiation
   - in `evaluate`: reset again immediately before the function call

2. Compare per-call fuel deltas:
   - capture fuel **before** and **after** the call
   - compare `consumed = before - after` between rwasm and wasmtime

3. Keep rwasm side call-scoped fuel accounting:
   - capture `before/after` around `engine.execute`

4. Update docs (`fuzz/README.md`):
   - explicitly describe per-invocation fuel reset + delta comparison.

## Validation
- `cargo check --manifest-path fuzz/Cargo.toml`
- `cd fuzz && cargo +nightly fuzz run differential -- -runs=2000`

Run completed with no fuel mismatch panic.
