### PR TITLE
fix(runtime): close rwasm audit follow-ups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+  - package-ecosystem: cargo
+    directory: '/'
+    schedule:
+      interval: daily
+  - package-ecosystem: cargo
+    directory: '/fuzz'
+    schedule:
+      interval: daily

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ arbitrary = "1.4.2"
 # Needed to map export names -> indices for snapshotting globals/tables/memory.
 # Use the same package/version as `rwasm` itself to avoid version skew.
 wasmparser = { version = "0.100.1", package = "wasmparser-nostd", default-features = false }
-wasmtime = { package = "wasmtime-rwasm", version = "41.0.2-rwasm.3" }
+wasmtime = { package = "wasmtime-rwasm", version = "45.0.0-rwasm.1" }
 wasm-smith = "0.243.0"
 hex = "0.4.3"
 log = "0.4.26"
@@ -43,5 +43,3 @@ default = ["disable-signals"]
 disable-signals = []
 
 [workspace]
-
-

--- a/src/compiler/translator.rs
+++ b/src/compiler/translator.rs
@@ -2450,7 +2450,7 @@ impl<'a> VisitOperator<'a> for InstructionTranslator {
                 .element_sections
                 .get(&elem_segment_index)
                 .copied()
-                .expect("can't resolve an element segment by index");
+                .ok_or(CompilationError::TableOutOfBounds)?;
             ib.op_table_init_checked(
                 segment_index + 1,
                 TableIdx::try_from(table_index).unwrap(),

--- a/src/types/untyped_value.rs
+++ b/src/types/untyped_value.rs
@@ -1,18 +1,6 @@
 use crate::{
-    ArithmeticOps,
-    ExtendInto,
-    Float,
-    Integer,
-    LittleEndianConvert,
-    LoadInto,
-    SignExtendFrom,
-    StoreFrom,
-    TrapCode,
-    TruncateSaturateInto,
-    TryTruncateInto,
-    WrapInto,
-    F32,
-    F64,
+    ArithmeticOps, ExtendInto, Float, Integer, LittleEndianConvert, LoadInto, SignExtendFrom,
+    StoreFrom, TrapCode, TruncateSaturateInto, TryTruncateInto, WrapInto, F32, F64,
 };
 use bincode::{Decode, Encode};
 use core::{
@@ -93,8 +81,28 @@ macro_rules! impl_from_unsigned_prim {
 }
 #[rustfmt::skip]
 impl_from_unsigned_prim!(
-    bool, u8, u16, u32, u64, usize,
+    bool, u8, u16, u32,
 );
+
+impl From<u64> for UntypedValue {
+    fn from(value: u64) -> Self {
+        debug_assert!(
+            value <= u32::MAX as u64,
+            "u64 value does not fit into UntypedValue"
+        );
+        Self { bits: value as _ }
+    }
+}
+
+impl From<usize> for UntypedValue {
+    fn from(value: usize) -> Self {
+        debug_assert!(
+            value <= u32::MAX as usize,
+            "usize value does not fit into UntypedValue"
+        );
+        Self { bits: value as _ }
+    }
+}
 
 macro_rules! impl_from_signed_prim {
     ( $( $prim:ty as $base:ty ),* $(,)? ) => {
@@ -973,6 +981,10 @@ impl UntypedValue {
 
 impl UntypedValue {
     pub fn as_u16(self) -> u16 {
+        debug_assert!(
+            self.bits <= u16::MAX as u32,
+            "UntypedValue does not fit into u16"
+        );
         u16::from(self)
     }
 

--- a/src/vm/store.rs
+++ b/src/vm/store.rs
@@ -1,7 +1,7 @@
 use crate::{
     CallStack, GlobalIdx, GlobalMemory, ImportLinker, InstructionPtr, Pages, RwasmModule,
     SignatureIdx, StoreTr, SyscallHandler, TableEntity, TableIdx, TrapCode, UntypedValue,
-    ValueStack, N_DEFAULT_MAX_MEMORY_PAGES,
+    ValueStack, N_DEFAULT_MAX_MEMORY_PAGES, N_MAX_ALLOWED_MEMORY_PAGES,
 };
 use alloc::{sync::Arc, vec::Vec};
 use bitvec::{order::Lsb0, vec::BitVec};
@@ -115,10 +115,11 @@ impl<T: 'static> RwasmStore<T> {
         fuel_limit: Option<u64>,
         max_allowed_memory_pages: Option<u32>,
     ) -> Self {
-        let global_memory = GlobalMemory::new(
-            Pages::new_unchecked(0),
-            Pages::new_unchecked(max_allowed_memory_pages.unwrap_or(N_DEFAULT_MAX_MEMORY_PAGES)),
-        );
+        let memory_pages = max_allowed_memory_pages
+            .unwrap_or(N_DEFAULT_MAX_MEMORY_PAGES)
+            .min(N_MAX_ALLOWED_MEMORY_PAGES);
+        let global_memory =
+            GlobalMemory::new(Pages::new_unchecked(0), Pages::new_unchecked(memory_pages));
         Self {
             consumed_fuel: 0,
             global_memory,
@@ -233,5 +234,27 @@ impl<T: 'static> RwasmStore<T> {
             .copied()
             .unwrap_or_default()
             .to_bits()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::always_failing_syscall_handler;
+
+    #[test]
+    fn clamps_runtime_memory_limit_to_global_maximum() {
+        let store = RwasmStore::new(
+            Arc::new(ImportLinker::default()),
+            (),
+            always_failing_syscall_handler,
+            None,
+            Some(N_MAX_ALLOWED_MEMORY_PAGES + 1),
+        );
+
+        assert_eq!(
+            u32::from(store.global_memory.max_allowed_memory_pages),
+            N_MAX_ALLOWED_MEMORY_PAGES
+        );
     }
 }

--- a/src/vm/tracer/mod.rs
+++ b/src/vm/tracer/mod.rs
@@ -131,7 +131,6 @@ impl Tracer {
             call_id: 0,
             memory_access,
         };
-        println!("opcode _state{:?},", opcode_state);
         self.logs.push(opcode_state);
     }
 
@@ -181,14 +180,9 @@ impl Tracer {
     pub fn record_mr(&mut self, ins: Opcode, sp: u32) -> MemoryAccessRecord {
         let length = opcode_stack_read(ins);
         let mut memory_access = MemoryAccessRecord::default();
-        println!(
-            "op:{},length:{},memory_record{:?}",
-            ins, length, self.memory_records
-        );
 
-        for idx in length..0 {
+        for idx in (0..length).rev() {
             let addr = sp - idx;
-            println!("length in loop{},addr:{}", length, addr);
             let record = self.memory_records.entry(addr).or_insert(MemoryRecord {
                 value: 0,
                 shard: 0,

--- a/tests/fuzz_versions.rs
+++ b/tests/fuzz_versions.rs
@@ -1,0 +1,19 @@
+fn wasmtime_rwasm_version(manifest: &str) -> Option<&str> {
+    manifest
+        .lines()
+        .find(|line| line.contains("package = \"wasmtime-rwasm\""))
+        .and_then(|line| line.split("version = \"").nth(1))
+        .and_then(|rest| rest.split('"').next())
+}
+
+#[test]
+fn fuzz_wasmtime_oracle_matches_root_wasmtime_version() {
+    let root = include_str!("../Cargo.toml");
+    let fuzz = include_str!("../fuzz/Cargo.toml");
+
+    assert_eq!(
+        wasmtime_rwasm_version(fuzz),
+        wasmtime_rwasm_version(root),
+        "fuzz oracle must use the same wasmtime-rwasm version as rwasm"
+    );
+}


### PR DESCRIPTION
## Summary
- clamp rwasm runtime memory limits to the same global maximum as the wasmtime executor
- align the fuzz wasmtime oracle with the root wasmtime-rwasm version and add a regression test
- convert remaining low-risk audit footguns: table.init compile error, tracer read loop/log spam, UntypedValue debug assertions, cargo Dependabot coverage

## Verification
- cargo test --test fuzz_versions
- cargo test -p rwasm vm::store::tests::clamps_runtime_memory_limit_to_global_maximum
- git diff --check

Note: cargo +nightly-2025-09-20 fmt --check still reports pre-existing formatting drift in src/compiler/segment_builder.rs, src/lib.rs, and src/types/mod.rs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Table initialization now reports compilation errors instead of panicking.
  * Runtime memory pages are clamped to configured maximum values.

* **Improvements**
  * Enhanced type conversion with built-in validation checks for data safety.
  * Removed debug logging noise from internal tracing.

* **Chores**
  * Updated wasmtime-rwasm dependency to version 45.0.0-rwasm.1.
  * Configured automated dependency management.
  * Added version consistency validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->