### PR TITLE
fix(runtime): meter bulk ops by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,12 +130,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,7 +1306,6 @@ dependencies = [
  "anyhow",
  "bincode",
  "bitvec",
- "bytes",
  "criterion",
  "directories",
  "downcast-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ wasmparser = { version = "0.100.1", package = "wasmparser-nostd", default-featur
 hashbrown = { version = "0.17.1", features = ["alloc"] }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 paste = { version = "1.0", default-features = false }
-bytes = { version = "1.10.1", default-features = false }
 downcast-rs = { version = "2.0.1", default-features = false, features = ["sync"] }
 bincode = { version = "2.0.1", default-features = false, features = ["alloc", "derive"] }
 num-traits = { version = "0.2", default-features = false }
@@ -49,7 +48,6 @@ fib-example = { path = "examples/fib" }
 [features]
 default = ["std", "wasmtime"]
 std = [
-    "bytes/std",
     "bincode/std",
     "num-traits/std",
     "bitvec/std",

--- a/src/compiler/config.rs
+++ b/src/compiler/config.rs
@@ -44,8 +44,9 @@ pub struct CompilationConfig {
     pub code_snippets: bool,
     /// Enable extra dynamic fuel checks for bulk memory/table instructions.
     ///
-    /// Keep this disabled for Wasmtime replacement paths unless the Wasmtime
-    /// fork charges the same dynamic fuel.
+    /// Secure production configs enable this with fuel metering. Wasmtime
+    /// replacement paths must either charge the same dynamic fuel or opt out
+    /// explicitly after rejecting the divergent config at a higher layer.
     pub consume_fuel_for_bulk_ops: bool,
     /// Enable fuel metering for params and locals
     ///
@@ -74,7 +75,7 @@ impl Default for CompilationConfig {
             builtins_consume_fuel: false,
             default_imported_global_value: None,
             consume_fuel: true,
-            consume_fuel_for_bulk_ops: false,
+            consume_fuel_for_bulk_ops: true,
             consume_fuel_for_params_and_locals: true,
             code_snippets: true,
             allow_func_ref_function_types: false,

--- a/src/vm/memory.rs
+++ b/src/vm/memory.rs
@@ -1,13 +1,12 @@
 use crate::types::{Pages, TrapCode};
-use alloc::vec::Vec;
-use bytes::BytesMut;
+use alloc::{vec, vec::Vec};
 
 /// Shared linear memory backing store for a running module.
 /// Tracks current size in Wasm pages and provides bounds-checked read/write helpers.
 /// The buffer is pre-reserved and grown in page-sized steps.
 pub struct GlobalMemory {
     /// Underlying byte buffer for the linear memory.
-    pub shared_memory: BytesMut,
+    pub shared_memory: Vec<u8>,
     /// Current logical size of the linear memory in pages.
     pub current_pages: Pages,
     /// The maximum allowed size of the linear memory in pages.
@@ -22,8 +21,7 @@ impl GlobalMemory {
         if initial_len > max_allowed_memory_pages.to_bytes().unwrap() {
             unreachable!("rwasm: initial memory size is greater than the maximum");
         }
-        let mut shared_memory = BytesMut::with_capacity(initial_len);
-        shared_memory.resize(initial_len, 0);
+        let shared_memory = vec![0; initial_len];
         Self {
             shared_memory,
             current_pages: initial_pages,
@@ -58,7 +56,10 @@ impl GlobalMemory {
         let new_size = desired_pages
             .to_bytes()
             .expect("rwasm: not supported target pointer width");
-        assert!(new_size >= self.shared_memory.len());
+        let additional_bytes = new_size.checked_sub(self.shared_memory.len())?;
+        if self.shared_memory.try_reserve_exact(additional_bytes).is_err() {
+            return None;
+        }
         self.shared_memory.resize(new_size, 0);
         self.current_pages = desired_pages;
         Some(current_pages)

--- a/src/vm/table_entity.rs
+++ b/src/vm/table_entity.rs
@@ -47,7 +47,12 @@ impl TableEntity {
         if desired > N_MAX_TABLE_SIZE {
             return u32::MAX;
         }
-        self.elements.resize(desired as usize, init.to_bits());
+        let desired_len = desired as usize;
+        let additional_elements = desired_len.saturating_sub(self.elements.len());
+        if self.elements.try_reserve(additional_elements).is_err() {
+            return u32::MAX;
+        }
+        self.elements.resize(desired_len, init.to_bits());
         current
     }
 

--- a/tests/compiler.rs
+++ b/tests/compiler.rs
@@ -7,6 +7,14 @@ fn test_compilation(wat_str: &str) -> Result<(RwasmModule, ConstructorParams), C
 }
 
 #[test]
+fn test_bulk_op_fuel_is_enabled_by_default() {
+    let config = CompilationConfig::default();
+
+    assert!(config.consume_fuel);
+    assert!(config.consume_fuel_for_bulk_ops);
+}
+
+#[test]
 fn test_bulk_op_fuel_requires_fuel_metering() {
     let config = CompilationConfig::default()
         .with_consume_fuel(false)

--- a/tests/fuel.rs
+++ b/tests/fuel.rs
@@ -156,7 +156,7 @@ fn test_memory_fill_fuel_scales_with_length() {
 }
 
 #[test]
-fn test_bulk_fuel_checks_are_disabled_by_default() {
+fn test_bulk_fuel_checks_are_enabled_by_default() {
     let wasm_binary = wat::parse_str(
         r#"
         (module
@@ -193,10 +193,10 @@ fn test_bulk_fuel_checks_are_disabled_by_default() {
 
     let default_short = consumed_for_len(base_config.clone(), 1);
     let default_long = consumed_for_len(base_config.clone(), 128);
-    let checked_long = consumed_for_len(base_config.with_consume_fuel_for_bulk_ops(true), 128);
+    let unchecked_long = consumed_for_len(base_config.with_consume_fuel_for_bulk_ops(false), 128);
 
-    assert_eq!(default_short, default_long);
-    assert!(checked_long > default_long);
+    assert!(default_long > default_short);
+    assert!(default_long > unchecked_long);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- enable dynamic fuel checks for bulk memory/table operations by default when fuel metering is enabled
- make runtime memory and table growth reserve fallibly before resizing
- update fuel coverage to assert the default charges by operation length

## Verification
- cargo test
- cargo clippy --all-targets -- -D warnings

Note: `cargo fmt --check` currently reports unrelated pre-existing rustfmt drift in `src/compiler/segment_builder.rs`, `src/lib.rs`, and `src/types/mod.rs` on this branch base.