### PR TITLE
fix(vm): bind suspended execution to module identity

### DIFF
--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -29,6 +29,10 @@ fn _check() {
 }
 
 impl RwasmModule {
+    pub(crate) fn has_same_identity(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
     pub fn new_or_empty(sink: &[u8]) -> (Self, usize) {
         if sink.is_empty() {
             (Self::empty(), 0)

--- a/src/types/trap_code.rs
+++ b/src/types/trap_code.rs
@@ -23,6 +23,10 @@ pub enum TrapCode {
     // a special trap code for interrupting an execution,
     // it saves the latest registers for IP and SP in the call stack
     InterruptionCalled = 0x0c,
+    AlreadySuspended = 0x0d,
+    NotSuspended = 0x0e,
+    WrongInstance = 0x0f,
+    IncompatibleModule = 0x10,
     // this trap code is only used for external calls to terminate the execution,
     // but this error can't be returned from an execution cycle
     ExecutionHalted = 0xff,
@@ -47,6 +51,10 @@ impl core::fmt::Display for TrapCode {
             TrapCode::UnknownExternalFunction => write!(f, "unknown external function"),
             TrapCode::IllegalOpcode => write!(f, "illegal opcode"),
             TrapCode::InterruptionCalled => write!(f, "interruption called"),
+            TrapCode::AlreadySuspended => write!(f, "execution is already suspended"),
+            TrapCode::NotSuspended => write!(f, "execution is not suspended"),
+            TrapCode::WrongInstance => write!(f, "suspended execution belongs to another instance"),
+            TrapCode::IncompatibleModule => write!(f, "suspended execution module is incompatible"),
             TrapCode::ExecutionHalted => write!(f, "execution halted"),
         }
     }

--- a/src/vm/engine.rs
+++ b/src/vm/engine.rs
@@ -50,6 +50,18 @@ impl ExecutionEngine {
         let mut ctx = self.inner.lock();
         ctx.resume(store, params, result)
     }
+
+    #[inline(always)]
+    pub(crate) fn resume_for_module<T>(
+        &self,
+        store: &mut RwasmStore<T>,
+        module: &RwasmModule,
+        params: &[Value],
+        result: &mut [Value],
+    ) -> Result<(), TrapCode> {
+        let mut ctx = self.inner.lock();
+        ctx.resume_for_module(store, module, params, result)
+    }
 }
 
 #[derive(Default)]
@@ -65,10 +77,9 @@ impl ExecutionEngineInner {
     ) -> Result<(), TrapCode> {
         let mut value_stack = ValueStack::default();
         let mut call_stack = CallStack::default();
-        debug_assert!(
-            store.resumable_context.is_none(),
-            "rwasm: resumable context is presented"
-        );
+        if store.resumable_context.is_some() {
+            return Err(TrapCode::AlreadySuspended);
+        }
         let mut executor =
             RwasmExecutor::entrypoint(module, &mut value_stack, &mut call_stack, store);
         match executor.run(&[], &mut []) {
@@ -91,10 +102,9 @@ impl ExecutionEngineInner {
     ) -> Result<(), TrapCode> {
         let mut value_stack = ValueStack::default();
         let mut call_stack = CallStack::default();
-        debug_assert!(
-            store.resumable_context.is_none(),
-            "rwasm: resumable context is presented"
-        );
+        if store.resumable_context.is_some() {
+            return Err(TrapCode::AlreadySuspended);
+        }
         let sp = value_stack.stack_ptr();
         let mut ip = InstructionPtr::new(module.code_section.as_ptr());
         debug_assert!(module.source_pc < module.code_section.len() as u32);
@@ -118,14 +128,46 @@ impl ExecutionEngineInner {
         params: &[Value],
         result: &mut [Value],
     ) -> Result<(), TrapCode> {
+        self.resume_checked(store, None, params, result)
+    }
+
+    pub(crate) fn resume_for_module<T>(
+        &mut self,
+        store: &mut RwasmStore<T>,
+        module: &RwasmModule,
+        params: &[Value],
+        result: &mut [Value],
+    ) -> Result<(), TrapCode> {
+        self.resume_checked(store, Some(module), params, result)
+    }
+
+    fn resume_checked<T>(
+        &mut self,
+        store: &mut RwasmStore<T>,
+        expected_module: Option<&RwasmModule>,
+        params: &[Value],
+        result: &mut [Value],
+    ) -> Result<(), TrapCode> {
+        let context = store
+            .resumable_context
+            .as_ref()
+            .ok_or(TrapCode::NotSuspended)?;
+        if expected_module.is_some_and(|module| !context.module.has_same_identity(module)) {
+            return Err(TrapCode::WrongInstance);
+        }
+
         let ReusableContext {
             module,
             mut call_stack,
-            ip,
+            instruction_index,
             mut value_stack,
-        } = take(&mut store.resumable_context).unwrap_or_else(|| {
-            unreachable!("resume calling without a remaining call stack");
-        });
+        } = take(&mut store.resumable_context).ok_or(TrapCode::NotSuspended)?;
+        let instruction_index = instruction_index as usize;
+        if instruction_index >= module.code_section.len() {
+            return Err(TrapCode::IncompatibleModule);
+        }
+        let mut ip = InstructionPtr::new(module.code_section.as_ptr());
+        ip.add(instruction_index);
         let sp = value_stack.stack_ptr();
         let mut executor =
             RwasmExecutor::new(&module, &mut value_stack, sp, &mut call_stack, ip, store);
@@ -147,10 +189,24 @@ impl ExecutionEngineInner {
         call_stack: CallStack,
         ip: InstructionPtr,
     ) -> Result<(), TrapCode> {
+        let base = module.code_section.as_ptr() as usize;
+        let current = ip.ptr as usize;
+        let byte_offset = current
+            .checked_sub(base)
+            .ok_or(TrapCode::IncompatibleModule)?;
+        if byte_offset % size_of::<crate::Opcode>() != 0 {
+            return Err(TrapCode::IncompatibleModule);
+        }
+        let instruction_index = byte_offset / size_of::<crate::Opcode>();
+        if instruction_index >= module.code_section.len() {
+            return Err(TrapCode::IncompatibleModule);
+        }
+        let instruction_index =
+            u32::try_from(instruction_index).map_err(|_| TrapCode::IncompatibleModule)?;
         store.resumable_context = Some(ReusableContext {
             module,
             call_stack,
-            ip,
+            instruction_index,
             value_stack,
         });
         Err(TrapCode::InterruptionCalled)

--- a/src/vm/instance.rs
+++ b/src/vm/instance.rs
@@ -34,6 +34,7 @@ impl RwasmInstance {
         params: &[Value],
         result: &mut [Value],
     ) -> Result<(), TrapCode> {
-        self.engine.resume(store, params, result)
+        self.engine
+            .resume_for_module(store, &self.module, params, result)
     }
 }

--- a/src/vm/store.rs
+++ b/src/vm/store.rs
@@ -1,7 +1,7 @@
 use crate::{
-    CallStack, GlobalIdx, GlobalMemory, ImportLinker, InstructionPtr, Pages, RwasmModule,
-    SignatureIdx, StoreTr, SyscallHandler, TableEntity, TableIdx, TrapCode, UntypedValue,
-    ValueStack, N_DEFAULT_MAX_MEMORY_PAGES, N_MAX_ALLOWED_MEMORY_PAGES,
+    CallStack, GlobalIdx, GlobalMemory, ImportLinker, Pages, RwasmModule, SignatureIdx, StoreTr,
+    SyscallHandler, TableEntity, TableIdx, TrapCode, UntypedValue, ValueStack,
+    N_DEFAULT_MAX_MEMORY_PAGES, N_MAX_ALLOWED_MEMORY_PAGES,
 };
 use alloc::{sync::Arc, vec::Vec};
 use bitvec::{order::Lsb0, vec::BitVec};
@@ -43,7 +43,7 @@ pub struct RwasmStore<T: 'static> {
 pub struct ReusableContext {
     pub module: RwasmModule,
     pub call_stack: CallStack,
-    pub ip: InstructionPtr,
+    pub instruction_index: u32,
     pub value_stack: ValueStack,
 }
 
@@ -140,6 +140,8 @@ impl<T: 'static> RwasmStore<T> {
 
     /// Resets the state of the current execution context.
     pub fn reset(&mut self, keep_flags: bool) {
+        // Reset also cancels suspended execution so stale stacks cannot be resumed later.
+        self.resumable_context = None;
         // reset consumed fuel to 0
         self.consumed_fuel = 0;
         // we might want to keep data/elem flags between calls, it's required for e2e tests

--- a/tests/interruption.rs
+++ b/tests/interruption.rs
@@ -71,7 +71,6 @@ fn resume_rejects_wrong_instance_without_losing_context() {
     })
     .build();
     let other_module = RwasmModuleBuilder::new(instruction_set! {
-        Nop
         Return
     })
     .build();

--- a/tests/interruption.rs
+++ b/tests/interruption.rs
@@ -64,6 +64,81 @@ fn test_interrupted_call_rwasm() {
 }
 
 #[test]
+fn resume_rejects_wrong_instance_without_losing_context() {
+    let interrupted_module = RwasmModuleBuilder::new(instruction_set! {
+        Call(0xff)
+        Return
+    })
+    .build();
+    let other_module = RwasmModuleBuilder::new(instruction_set! {
+        Nop
+        Return
+    })
+    .build();
+    let mut store = RwasmStore::new(
+        default_import_linker(),
+        (),
+        interrupting_syscall_handler,
+        None,
+        None,
+    );
+    let engine = ExecutionEngine::new();
+    let interrupted_instance =
+        rwasm::RwasmInstance::new(&mut store, engine.clone(), interrupted_module).unwrap();
+    let other_instance = rwasm::RwasmInstance::new(&mut store, engine, other_module).unwrap();
+
+    assert_eq!(
+        interrupted_instance.execute(&mut store, &[], &mut []),
+        Err(TrapCode::InterruptionCalled)
+    );
+    assert_eq!(
+        other_instance.resume(&mut store, &[], &mut []),
+        Err(TrapCode::WrongInstance)
+    );
+    assert_eq!(
+        interrupted_instance.resume(&mut store, &[], &mut []),
+        Ok(())
+    );
+}
+
+#[test]
+fn suspended_execution_preconditions_are_typed_errors() {
+    let module = RwasmModuleBuilder::new(instruction_set! {
+        Call(0xff)
+        Return
+    })
+    .build();
+    let mut store = RwasmStore::new(
+        default_import_linker(),
+        (),
+        interrupting_syscall_handler,
+        None,
+        None,
+    );
+    let engine = ExecutionEngine::new();
+    let instance = rwasm::RwasmInstance::new(&mut store, engine, module).unwrap();
+
+    assert_eq!(
+        instance.resume(&mut store, &[], &mut []),
+        Err(TrapCode::NotSuspended)
+    );
+    assert_eq!(
+        instance.execute(&mut store, &[], &mut []),
+        Err(TrapCode::InterruptionCalled)
+    );
+    assert_eq!(
+        instance.execute(&mut store, &[], &mut []),
+        Err(TrapCode::AlreadySuspended)
+    );
+
+    store.reset(false);
+    assert_eq!(
+        instance.resume(&mut store, &[], &mut []),
+        Err(TrapCode::NotSuspended)
+    );
+}
+
+#[test]
 fn test_interrupted_call_rwasm_with_syscall() {
     let wasm_binary = wat::parse_str(
         r#"


### PR DESCRIPTION
## Summary
- bind suspended contexts to the originating module identity and reject wrong-instance resume
- store and range-check a module-relative instruction index instead of retaining the active raw IP
- return typed errors for already/not suspended and incompatible contexts; reset cancels suspension
- add regression coverage for wrong-instance resume, context preservation, typed preconditions, and reset cancellation

## Verification
- `cargo test --test interruption`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

`cargo fmt --check` still reports pre-existing formatting drift in unrelated files on `origin/devel`; all touched files were formatted directly.

Linear: FLU-951