### PR TITLE
fix(module): propagate builder verification errors

### DIFF
--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -269,20 +269,21 @@ impl RwasmModuleBuilder {
         self
     }
 
-    pub fn build(self) -> RwasmModule {
-        RwasmModuleInner {
+    pub fn build(self) -> Result<RwasmModule, RwasmModuleVerificationError> {
+        RwasmModule::from_verified_inner(RwasmModuleInner {
             code_section: self.code_section,
             data_section: self.data_section,
             elem_section: self.elem_section,
             hint_section: self.hint_section,
             source_pc: self.source_pc,
-        }
-        .into()
+        })
     }
 }
 
-impl From<RwasmModuleBuilder> for RwasmModule {
-    fn from(val: RwasmModuleBuilder) -> Self {
+impl TryFrom<RwasmModuleBuilder> for RwasmModule {
+    type Error = RwasmModuleVerificationError;
+
+    fn try_from(val: RwasmModuleBuilder) -> Result<Self, Self::Error> {
         val.build()
     }
 }

--- a/src/module/verification.rs
+++ b/src/module/verification.rs
@@ -81,6 +81,13 @@ impl RwasmModuleInner {
 }
 
 impl RwasmModule {
+    pub(crate) fn from_verified_inner(
+        inner: RwasmModuleInner,
+    ) -> Result<Self, RwasmModuleVerificationError> {
+        inner.verify()?;
+        Ok(inner.into())
+    }
+
     pub fn verify(&self) -> Result<(), RwasmModuleVerificationError> {
         self.inner.verify()
     }
@@ -322,17 +329,28 @@ mod tests {
     }
 
     #[test]
-    fn regular_construction_does_not_verify() {
+    fn direct_construction_does_not_verify() {
         let module: RwasmModule = module_with_code(InstructionSet::new()).into();
         assert_eq!(
             module.verify(),
             Err(RwasmModuleVerificationError::EmptyCodeSection)
         );
+    }
 
-        let module = RwasmModuleBuilder::new(InstructionSet::new()).build();
+    #[test]
+    fn builder_propagates_verification_errors() {
         assert_eq!(
-            module.verify(),
+            RwasmModuleBuilder::new(InstructionSet::new()).build(),
             Err(RwasmModuleVerificationError::EmptyCodeSection)
+        );
+        assert_eq!(
+            RwasmModuleBuilder::new(instruction_set! { Return })
+                .with_source_pc(1)
+                .build(),
+            Err(RwasmModuleVerificationError::SourcePcOutOfBounds {
+                source_pc: 1,
+                code_len: 1,
+            })
         );
     }
 

--- a/tests/interruption.rs
+++ b/tests/interruption.rs
@@ -41,7 +41,8 @@ fn test_interrupted_call_rwasm() {
         Return
     })
     .with_source_pc(1)
-    .build();
+    .build()
+    .unwrap();
     let import_linker = default_import_linker();
     let mut store = RwasmStore::<()>::new(
         import_linker,
@@ -252,7 +253,8 @@ fn test_call_stack_empty_after_trap_in_nested_call() {
         Call(0xff)
         Trap(TrapCode::UnreachableCodeReached)
     })
-    .build();
+    .build()
+    .unwrap();
     let import_linker = default_import_linker();
     let mut store = RwasmStore::<()>::new(
         import_linker,
@@ -291,7 +293,8 @@ fn test_memory_write_during_interruption() {
         Return
     })
     .with_source_pc(1)
-    .build();
+    .build()
+    .unwrap();
     let import_linker = default_import_linker();
 
     let test_strategy = |strategy: StrategyDefinition| {

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -43,7 +43,8 @@ fn test_memory_fuel_ddos_not_possible() {
     };
     let rwasm_module = RwasmModuleBuilder::new(code_section)
         .with_data_section(&[0x01, 0x02, 0x03])
-        .build();
+        .build()
+        .unwrap();
     println!("{}", rwasm_module);
     let fuel_consumed = execute_module(&rwasm_module);
     assert_eq!(fuel_consumed, 3);

--- a/tests/snippets.rs
+++ b/tests/snippets.rs
@@ -62,7 +62,7 @@ use std::{
 
 fn run_vm_instr(mut is: InstructionSet, inputs: Vec<u32>) -> Result<(Vec<u32>, u32), TrapCode> {
     is.op_return();
-    let rwasm_module = RwasmModuleBuilder::new(is).build();
+    let rwasm_module = RwasmModuleBuilder::new(is).build().unwrap();
     let mut value_stack = ValueStack::default();
     assert_eq!(value_stack.max_stack_height(), 0);
     value_stack.reserve(10)?;


### PR DESCRIPTION
Follow-up to #162.

- make RwasmModuleBuilder::build return a recoverable verification result
- validate public InstructionSet and source_pc inputs before construction
- replace infallible From with TryFrom
- update successful callers and add invalid-builder regression coverage

Validation: cargo test; make clippy; focused module tests; formatting and diff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Module construction now verifies modules before they can be used.
  * Invalid modules return clear verification errors instead of being created unchecked.
  * Module conversion now reports construction failures explicitly.
* **Tests**
  * Updated execution and memory tests to handle module verification failures during setup.
  * Added coverage for specific invalid module conditions, including out-of-bounds source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->