### PR TITLE
fix(compiler): respect bulk fuel config for initial memory

### DIFF
--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -598,7 +598,11 @@ impl ModuleParser {
             self.allocations
                 .translation
                 .segment_builder
-                .add_memory_pages(initial_memory, self.config.max_allowed_memory_pages)?;
+                .add_memory_pages(
+                    initial_memory,
+                    self.config.max_allowed_memory_pages,
+                    self.config.consume_fuel_for_bulk_ops,
+                )?;
         }
         Ok(())
     }

--- a/src/compiler/segment_builder.rs
+++ b/src/compiler/segment_builder.rs
@@ -73,10 +73,10 @@ impl SegmentBuilder {
         &mut self,
         initial_pages: u32,
         max_allowed_memory_pages: u32,
+        consume_fuel_for_bulk_ops: bool,
     ) -> Result<(), CompilationError> {
         // there is a hard limit of max possible memory used (~64 mB)
-        let next_pages = self
-            .total_allocated_pages.saturating_add(initial_pages);
+        let next_pages = self.total_allocated_pages.saturating_add(initial_pages);
         if next_pages >= max_allowed_memory_pages {
             return Err(CompilationError::MaxReadonlyDataReached);
         }
@@ -84,7 +84,8 @@ impl SegmentBuilder {
         if initial_pages > 0 {
             // TODO(dmitry123): "add stack height check?"
             self.entrypoint_bytecode.op_i32_const(initial_pages);
-            self.entrypoint_bytecode.op_memory_grow_checked(None, false);
+            self.entrypoint_bytecode
+                .op_memory_grow_checked(None, consume_fuel_for_bulk_ops);
             // there is no need to verify for a potential trap because it can't overflow,
             // we have this check upper during the compilation time
             self.entrypoint_bytecode.op_drop();

--- a/tests/fuel.rs
+++ b/tests/fuel.rs
@@ -31,6 +31,43 @@ fn test_entrypoint_call_consumes_fuel() {
 }
 
 #[test]
+fn test_initial_memory_fuel_respects_bulk_ops_config() {
+    const INITIAL_MEMORY_PAGES: u64 = 2;
+
+    let wasm_binary = wat::parse_str(
+        r#"
+        (module
+          (memory 2)
+          (func (export "entry"))
+        )
+        "#,
+    )
+    .unwrap();
+    let fuel_limit = 100_000;
+
+    let consumed_by_entrypoint = |consume_fuel_for_bulk_ops| {
+        let config = CompilationConfig::default()
+            .with_entrypoint_name("entry".into())
+            .with_consume_fuel(true)
+            .with_consume_fuel_for_bulk_ops(consume_fuel_for_bulk_ops);
+        let (module, _) = RwasmModule::compile(config, &wasm_binary).unwrap();
+        let mut store = RwasmStore::<()>::default();
+        store.reset_fuel(fuel_limit);
+        ExecutionEngine::new()
+            .entrypoint(&mut store, &module)
+            .unwrap();
+        fuel_limit - store.remaining_fuel().unwrap()
+    };
+
+    assert_eq!(
+        consumed_by_entrypoint(true),
+        INITIAL_MEMORY_PAGES * rwasm::N_BYTES_PER_MEMORY_PAGE as u64
+            / rwasm_fuel_policy::MEMORY_BYTES_PER_FUEL as u64
+    );
+    assert_eq!(consumed_by_entrypoint(false), 0);
+}
+
+#[test]
 fn test_locals_consume_fuel() {
     let fuel_limit = 9999;
     let basic_fuel_consumption = 2;

--- a/tests/fuzz.rs
+++ b/tests/fuzz.rs
@@ -11,7 +11,8 @@ fn run_rwasm_vs_wasmtime_fuel_check(wasm_binary: &[u8], params: &[Value], result
         .with_consume_fuel(true)
         .with_consume_fuel_for_params_and_locals(false)
         .with_allow_func_ref_function_types(false)
-        .with_max_allowed_memory_pages(4096);
+        .with_max_allowed_memory_pages(4096)
+        .with_consume_fuel_for_bulk_ops(false);
     let (module, _) = RwasmModule::compile(config.clone(), wasm_binary).unwrap();
     println!("{}", module);
     let fuel_consumed = for_each_strategy(
@@ -156,6 +157,38 @@ fn test_fuel_memory_oom() {
   (export "memory" (memory 0))
   (export "3" (global 0))
   (func (;0;) (type 0))
+)
+"#,
+        )
+        .unwrap(),
+        &[],
+        &mut [],
+    );
+}
+
+#[test]
+fn test_fuel_large_initial_memory_with_recursive_calls() {
+    run_rwasm_vs_wasmtime_fuel_check(
+        &wat::parse_str(
+            r#"
+(module
+  (type (;0;) (func))
+  (memory (;0;) 1023)
+  (global (;0;) (mut i32) i32.const 1024)
+  (export "" (func 0))
+  (export "memory" (memory 0))
+  (func (;0;) (type 0)
+    global.get 0
+    i32.eqz
+    if
+      return
+    end
+    global.get 0
+    i32.const 1
+    i32.sub
+    global.set 0
+    return_call 0
+  )
 )
 "#,
         )


### PR DESCRIPTION
## Summary

- Pass the bulk-operation fuel configuration through initial memory allocation.
- Charge fuel for compiler-initialized memory growth when bulk-operation fuel is enabled.
- Add coverage for both fuel configuration modes and large initial memory with recursive calls.

## Testing

- Added fuel accounting and Wasmtime comparison regression tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fuel accounting for initial memory allocation when bulk-operation fuel tracking is enabled.
  * Ensured memory growth consistently respects the configured fuel policy.
  * Improved fuel consistency for modules with large initial memory and recursive execution paths.

* **Tests**
  * Added coverage for fuel usage with enabled and disabled bulk-operation tracking.
  * Added validation for fuel behavior in large-memory modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->