### PR TITLE
fix(vm): grow-only dropped-segment bitset in data.drop/elem.drop

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -159,6 +159,10 @@ fn execute_one(data: &[u8]) -> Result<()> {
     gen_cfg.max_tables = 1;
     // Keep wasm-smith table limits inside rwasm runtime hard cap.
     gen_cfg.max_table_elements = rwasm::N_MAX_TABLE_SIZE as u64;
+    // Force several segments so `data.drop`/`elem.drop` sequences with descending indices
+    // are reachable, they used to truncate the dropped-segment bitset.
+    gen_cfg.min_data_segments = 4;
+    gen_cfg.min_element_segments = 4;
     gen_cfg.export_everything = true;
 
     STATS.wasm_smith_modules.fetch_add(1, SeqCst);

--- a/src/vm/executor/memory.rs
+++ b/src/vm/executor/memory.rs
@@ -157,8 +157,13 @@ impl<'a, T> RwasmExecutor<'a, T> {
     #[inline(always)]
     pub(crate) fn visit_data_drop(&mut self, data_segment_idx: DataSegmentIdx) {
         let empty_data_segments = &mut self.store.empty_data_segments;
-        empty_data_segments.resize(data_segment_idx as usize + 1, false);
-        empty_data_segments.set(data_segment_idx as usize, true);
+        // grow only, `resize` would truncate the bitset and forget previously dropped segments
+        // with a higher index
+        let idx = data_segment_idx as usize;
+        if idx >= empty_data_segments.len() {
+            empty_data_segments.resize(idx + 1, false);
+        }
+        empty_data_segments.set(idx, true);
         self.ip.add(1);
     }
 }

--- a/src/vm/executor/table.rs
+++ b/src/vm/executor/table.rs
@@ -149,8 +149,13 @@ impl<'a, T> RwasmExecutor<'a, T> {
     #[inline(always)]
     pub(crate) fn visit_element_drop(&mut self, element_segment_idx: ElementSegmentIdx) {
         let empty_elem_segments = &mut self.store.empty_elem_segments;
-        empty_elem_segments.resize(element_segment_idx as usize + 1, false);
-        empty_elem_segments.set(element_segment_idx as usize, true);
+        // grow only, `resize` would truncate the bitset and forget previously dropped segments
+        // with a higher index
+        let idx = element_segment_idx as usize;
+        if idx >= empty_elem_segments.len() {
+            empty_elem_segments.resize(idx + 1, false);
+        }
+        empty_elem_segments.set(idx, true);
         self.ip.add(1);
     }
 }

--- a/tests/segment_drop.rs
+++ b/tests/segment_drop.rs
@@ -1,0 +1,92 @@
+use rwasm::{
+    always_failing_syscall_handler, instruction_set, ExecutionEngine, ImportLinker, InstructionSet,
+    RwasmModuleBuilder, RwasmStore, TrapCode,
+};
+
+fn execute(code_section: InstructionSet, data: &[u8], elem: &[u32]) -> Result<(), TrapCode> {
+    let module = RwasmModuleBuilder::new(code_section)
+        .with_data_section(data)
+        .with_elem_section(elem)
+        .build();
+    let engine = ExecutionEngine::new();
+    let mut store = RwasmStore::new(
+        ImportLinker::default().into(),
+        (),
+        always_failing_syscall_handler,
+        None,
+        None,
+    );
+    engine
+        .execute(&mut store, &module, &[], &mut [])
+        .map(|_| ())
+}
+
+fn data_drop_code(dropped: &[u32]) -> InstructionSet {
+    let mut code = instruction_set! {
+        I32Const(1)
+        MemoryGrow
+        Drop
+    };
+    for segment in dropped {
+        code.op_data_drop(*segment);
+    }
+    code.op_i32_const(0); // d
+    code.op_i32_const(0); // s
+    code.op_i32_const(1); // n
+    code.op_memory_init(5);
+    code.op_return();
+    code
+}
+
+fn elem_drop_code(dropped: &[u32]) -> InstructionSet {
+    let mut code = instruction_set! {
+        I32Const(0) // init
+        I32Const(1) // delta
+        TableGrow(0)
+        Drop
+    };
+    for segment in dropped {
+        code.op_elem_drop(*segment);
+    }
+    code.op_i32_const(0); // d
+    code.op_i32_const(0); // s
+    code.op_i32_const(1); // n
+    code.op_table_init(5);
+    code.op_table_get(0); // table index payload of `table.init`
+    code.op_return();
+    code
+}
+
+#[test]
+fn test_data_drop_keeps_higher_dropped_segments() {
+    let data = &[0xaa, 0xbb, 0xcc, 0xdd];
+    // not dropped at all, `memory.init` reads the real data section
+    assert_eq!(execute(data_drop_code(&[]), data, &[]), Ok(()));
+    // dropped, `memory.init` must observe a zero-length segment and trap
+    assert_eq!(
+        execute(data_drop_code(&[5]), data, &[]),
+        Err(TrapCode::MemoryOutOfBounds),
+    );
+    // dropping a lower-indexed segment afterward must not resurrect segment 5
+    assert_eq!(
+        execute(data_drop_code(&[5, 2]), data, &[]),
+        Err(TrapCode::MemoryOutOfBounds),
+    );
+}
+
+#[test]
+fn test_elem_drop_keeps_higher_dropped_segments() {
+    let elem = &[1u32, 2, 3, 4];
+    // not dropped at all, `table.init` reads the real element section
+    assert_eq!(execute(elem_drop_code(&[]), &[], elem), Ok(()));
+    // dropped, `table.init` must observe a zero-length segment and trap
+    assert_eq!(
+        execute(elem_drop_code(&[5]), &[], elem),
+        Err(TrapCode::TableOutOfBounds),
+    );
+    // dropping a lower-indexed segment afterward must not resurrect segment 5
+    assert_eq!(
+        execute(elem_drop_code(&[5, 2]), &[], elem),
+        Err(TrapCode::TableOutOfBounds),
+    );
+}


### PR DESCRIPTION
Fixes [FLU-1100](https://linear.app/fluentlabs-xyz/issue/FLU-1100/high-7-datadrop-elemdrop-truncate-the-dropped-segment-bitset).

## Problem

`visit_data_drop` and `visit_element_drop` used `BitVec::resize(idx + 1, false)` to make room for the bit they set. `resize` also **shrinks**, so dropping a lower-indexed segment after a higher-indexed one truncated the bitset and discarded the record of the earlier drop:

```
data.drop 5   -> bitset len 6, bit 5 = true
data.drop 2   -> resize(3) drops bit 5
memory.init 5 -> `.get(5).unwrap_or(false)` reads "not dropped", copies real data
```

Per the Wasm spec a dropped segment must behave as zero-length, so `memory.init` / `table.init` on it has to trap. rwasm instead succeeded and copied data — a state divergence from wasmtime on the same module.

## Fix

Grow the bitset only when the index is beyond its current length, then set the bit. Applied identically in `visit_data_drop` ([src/vm/executor/memory.rs](https://github.com/fluentlabs-xyz/rwasm/blob/claude/datadrop-elemdrop-bitset-693a70/src/vm/executor/memory.rs)) and `visit_element_drop` ([src/vm/executor/table.rs](https://github.com/fluentlabs-xyz/rwasm/blob/claude/datadrop-elemdrop-bitset-693a70/src/vm/executor/table.rs)).

Segment indices are bounded by `N_MAX_DATA_SEGMENTS` / `N_MAX_ELEM_SEGMENTS` (100_000) in `verify_opcode` for all four opcodes that reach these paths (`MemoryInit`, `DataDrop`, `TableInit`, `ElemDrop`), so worst-case growth stays at ~12.5 KiB per bitset.

## Tests

New `tests/segment_drop.rs` covers both opcodes with three cases each: no drop (succeeds), single drop (traps), and descending drop `5` then `2` (must still trap). Both descending cases fail on `devel` and pass with the fix.

The fuzz generator is nudged toward the pattern that was missed: `min_data_segments` / `min_element_segments` are set to 4 in `fuzz/fuzz_targets/differential.rs`, so generated modules reliably contain several segments and can emit descending drop sequences. Note the `rwasm-fuzz` crate does not compile on `devel` for an unrelated reason (a missing `Context` trait import at `differential.rs:709`), so that change is unverified by a build.

## Verification

- `cargo test` — full suite green
- `cargo clippy --all-targets` — clean
