### PR TITLE
fix(vm): trap on stack oob at every executor exit

### DIFF
--- a/src/vm/executor.rs
+++ b/src/vm/executor.rs
@@ -205,13 +205,19 @@ impl<'a, T> RwasmExecutor<'a, T> {
     /// With [`TrapCode::StackOverflow`] if `instr` addressed a cell outside the value stack. The
     /// offending access itself was already suppressed by [`ValueStackPtr`], this only stops the
     /// execution from carrying on with a corrupted stack.
+    ///
+    /// An out-of-bounds access outranks whatever `instr` reported on its own: that trap is an
+    /// artifact of the values the suppressed access substituted. The check therefore runs before
+    /// the instruction's own error is propagated — otherwise every exit that carries an error out
+    /// of [`RwasmExecutor::run`] would drop the flag, and [`TrapCode::ExecutionHalted`] returned by
+    /// a host function would even turn the run into a success.
     #[inline(always)]
     pub fn step(&mut self, instr: Opcode) -> Result<bool, TrapCode> {
-        let return_reached = self.execute(instr)?;
+        let result = self.execute(instr);
         if self.sp.is_out_of_bounds() {
             return Err(TrapCode::StackOverflow);
         }
-        Ok(return_reached)
+        result
     }
 
     #[inline(always)]
@@ -454,6 +460,11 @@ impl<'a, T> RwasmExecutor<'a, T> {
         buffer.resize(params.len() + result.len(), Value::I32(0));
         for (i, x) in params.iter().enumerate() {
             buffer[params.len() - i - 1] = self.sp.pop_value(*x);
+        }
+        // A parameter popped from outside the value stack is a fabricated zero. The host must not
+        // observe it: its side effects would happen before `step` gets to see the flag.
+        if self.sp.is_out_of_bounds() {
+            return Err(TrapCode::StackOverflow);
         }
         for (i, x) in result.iter().enumerate() {
             buffer[params.len() + i] = Value::default(*x);

--- a/tests/value-stack-bounds.rs
+++ b/tests/value-stack-bounds.rs
@@ -9,10 +9,12 @@
 //! code; those cases are caught by the runtime bounds checks alone.
 
 use rwasm::{
-    instruction_set, ExecutionEngine, ImportLinker, InstructionSet, RwasmModule,
-    RwasmModuleBuilder, RwasmStore, TrapCode,
+    instruction_set, ExecutionEngine, ImportLinker, ImportName, InstructionSet, RwasmModule,
+    RwasmModuleBuilder, RwasmStore, StoreTr, TrapCode, TypedCaller, Value,
 };
+use rwasm_fuel_policy::SyscallFuelParams;
 use std::sync::Arc;
+use wasmparser::ValType;
 
 fn execute(code_section: InstructionSet) -> Result<(), TrapCode> {
     let module = RwasmModuleBuilder::new(code_section).build();
@@ -95,6 +97,78 @@ fn popping_below_the_stack_base_traps() {
         StackCheck(16)
         I32Const(1)
         I32Add
+        Return
+    };
+    assert_eq!(execute(code), Err(TrapCode::StackOverflow));
+}
+
+/// A syscall whose parameters underflow the value stack must trap before the host observes them.
+///
+/// Verification accepts this module — the emulated stack height is `Unknown` after any call — so
+/// the runtime is the only thing standing between a malformed module and the host. Popping a
+/// parameter that is not there yields a fabricated zero, and the handler returning
+/// `ExecutionHalted` would otherwise carry the whole run out as a success.
+#[test]
+fn syscall_with_underflowing_params_traps_before_reaching_the_host() {
+    const EXIT_IDX: u32 = 75;
+
+    fn halting_handler(
+        caller: &mut TypedCaller<'_, Vec<i32>>,
+        _idx: u32,
+        params: &[Value],
+        _result: &mut [Value],
+    ) -> Result<(), TrapCode> {
+        caller
+            .data_mut()
+            .extend(params.iter().map(|p| p.i32().unwrap_or(i32::MIN)));
+        Err(TrapCode::ExecutionHalted)
+    }
+
+    let mut import_linker = ImportLinker::default();
+    import_linker.insert_function(
+        ImportName::new("fluentbase_v1preview", "_exit"),
+        EXIT_IDX,
+        SyscallFuelParams::default(),
+        &[ValType::I32],
+        &[],
+    );
+
+    let code = instruction_set! {
+        StackCheck(16)
+        Call(EXIT_IDX)
+        Return
+    };
+    assert!(
+        verify(code.clone()).is_ok(),
+        "verification cannot catch this one"
+    );
+
+    let module = RwasmModuleBuilder::new(code).build();
+    let mut store = RwasmStore::new(
+        Arc::new(import_linker),
+        Vec::<i32>::new(),
+        halting_handler,
+        Some(1_000_000),
+        None,
+    );
+    let result = ExecutionEngine::new().execute(&mut store, &module, &[], &mut []);
+
+    assert_eq!(result, Err(TrapCode::StackOverflow));
+    assert!(
+        store.data().is_empty(),
+        "the host must not have been called: {:?}",
+        store.data()
+    );
+}
+
+/// An instruction that both underflows the stack and traps on its own terms reports the underflow:
+/// the trap it raised is an artifact of the zero the suppressed pop substituted.
+#[test]
+fn a_trap_caused_by_an_underflow_is_reported_as_the_underflow() {
+    let code = instruction_set! {
+        StackCheck(16)
+        I32Const(0)
+        I32DivU
         Return
     };
     assert_eq!(execute(code), Err(TrapCode::StackOverflow));


### PR DESCRIPTION
Follow-up to #171, on top of its branch.

## Problem

`RwasmExecutor::step` checks the out-of-bounds flag only after `execute` returns `Ok`:

```rust
let return_reached = self.execute(instr)?;   // <- any Err short-circuits the check below
if self.sp.is_out_of_bounds() {
    return Err(TrapCode::StackOverflow);
}
```

Every exit that carries an error out of the instruction loop therefore drops the flag. `run` then calls `value_stack.reset()`, which clears it, and for `TrapCode::ExecutionHalted` returns `Ok(())` — the one place in the interpreter that converts an `Err` into a success. `run_with_stack_check` and the `InterruptionCalled` branch lose it the same way.

That is reachable from bytecode `new_verified` accepts:

```
StackCheck(16)
Call(_exit)      ; the host function takes one i32, and the stack is empty
Return
```

Verification accepts the module — the emulated stack height turns `Unknown` after any call, a documented limitation of the pass added in #171. At runtime the syscall pops its parameter off an empty stack, the pop is suppressed and substitutes a zero, the host handler runs with that fabricated argument, returns `ExecutionHalted`, and `execute` hands the caller `Ok(())`. An invalid module finishes as a successful halt, after the host has already committed a side effect on values the module never pushed.

## Fix

**`step` converts the flag before the instruction's own error is propagated.** Binding the result first covers every exit at once — both loops, the `ExecutionHalted` branch and the `InterruptionCalled` branch — so `run` and `run_with_stack_check` need no change:

```rust
let result = self.execute(instr);
if self.sp.is_out_of_bounds() {
    return Err(TrapCode::StackOverflow);
}
result
```

**`invoke_syscall` traps after popping its parameters, before the handler runs.** This one cannot be folded into `step`: `step` sees the flag only once the instruction returns, and by then the host has already observed the fabricated zeros and acted on them.

The existing check after the result-collection pops in `run` stays — those pops happen outside `step`.

## Trap-code precedence

An out-of-bounds access now outranks the trap the instruction reported on its own. `I32DivU` on an underflowed stack reports `IntegerDivisionByZero` only because the suppressed pop fed it a zero divisor; the underflow is the cause, the division is the symptom.

The blast radius was measured rather than assumed: with `ValueStackPtr::mark_out_of_bounds` patched to `panic!`, 120 tests across the lib, `compiler`, `fuel`, `locals`, `memory`, `stack-overflow`, `snippets` and `intrinsic` pass without a single hit. Nothing `RwasmModule::compile` emits ever raises the flag, so the rule is observable only through `RwasmModule::new_verified`. The differential fuzzer is unaffected as well: it treats any trap on both sides as equivalent, and every module it generates goes through the compiler.

## Tests

Two tests in `tests/value-stack-bounds.rs`, each pinning one of the two gates:

- `syscall_with_underflowing_params_traps_before_reaching_the_host` — the repro above. Asserts `Err(TrapCode::StackOverflow)` and that the handler recorded nothing, and documents that `new_verified` accepts the module. On the parent branch it fails with `left: Ok(())`. With only the syscall gate removed it fails on the second assertion, with the handler having seen `[0]`.
- `a_trap_caused_by_an_underflow_is_reported_as_the_underflow` — `StackCheck(16); I32Const(0); I32DivU; Return`. On the parent branch it fails with `left: Err(IntegerDivisionByZero)`. This is the only bytecode-level way to exercise the precedence rule, and it is the test that fails if the `step` change alone is reverted.

`InterruptionCalled` gets no dedicated test on purpose: after this change it is not a separate code path, and once the syscall gate is in place there is no way to raise the flag inside an instruction that goes on to return it, since handlers are the only producers of that trap code.

## Verification

- `cargo test` — 179 passed, 4 ignored, including `interruption`, `wasmtime`, `fluentbase` and `fuzz`.
- `cargo test --no-default-features --features std` over the targets that build without the wasmtime feature — 130 passed.
- `cargo clippy --all-targets` clean.
- `cargo +nightly-2025-09-20 fmt --check` reports no diff in either touched file.
