### PR TITLE
perf(isa): rewrite i64 shift/rotate snippet bodies by hand (778 -> 170 instrs)

### DIFF
--- a/src/isa/bitwise.rs
+++ b/src/isa/bitwise.rs
@@ -7,11 +7,11 @@ impl InstructionSet {
     pub const MSH_I64_AND: u32 = 0;
     pub const MSH_I64_OR: u32 = 0;
     pub const MSH_I64_XOR: u32 = 0;
-    pub const MSH_I64_SHL: u32 = 9;
-    pub const MSH_I64_SHR_S: u32 = 21;
-    pub const MSH_I64_SHR_U: u32 = 21;
-    pub const MSH_I64_ROTL: u32 = 16;
-    pub const MSH_I64_ROTR: u32 = 16;
+    pub const MSH_I64_SHL: u32 = 3;
+    pub const MSH_I64_SHR_S: u32 = 3;
+    pub const MSH_I64_SHR_U: u32 = 3;
+    pub const MSH_I64_ROTL: u32 = 4;
+    pub const MSH_I64_ROTR: u32 = 4;
 
     /// Max stack height: 3
     pub fn op_i64_clz(&mut self) {
@@ -69,811 +69,219 @@ impl InstructionSet {
         self.op_i32_xor64();
     }
 
-    /// Max stack height: 9
+    // The i64 shift/rotate bodies below share one convention: entry stack (top first) is
+    // [n_hi, n_lo, x_hi, x_lo]; exit stack is [res_hi, res_lo]. Each body first reduces the
+    // shift amount to n = n_lo & 63 (n_hi is dropped, wasm ignores it), then branches once on
+    // n < 32. Within an arm the code is branchless: i32 shifts mask their amount by 31, so
+    // expressions like `x << n` (n in 32..63) and `y >> (31 - n)` (31 - n negative) reduce to
+    // the intended `x << (n - 32)` and `y >> (63 - n)` automatically. Cross-limb carries use
+    // `(y >> 1) >> (31 - n)` instead of `y >> (32 - n)` so that n = 0 yields 0 instead of a
+    // full-width shift.
+
+    /// Max stack height: 3
     pub fn op_i64_shl(&mut self) {
-        self.op_i32_const(0);
-        self.op_i32_const(0);
-        self.op_local_get(4);
+        // [n_hi, n_lo, x_hi, x_lo]
+        self.op_drop();
         self.op_i32_const(63);
-        self.op_i32_and();
-        self.op_local_tee(3);
-        self.op_br_if_nez(4);
-        self.op_local_get(6);
-        self.op_local_set(1);
-        self.op_br(44);
-        self.op_local_get(2);
-        self.op_i32_const(32);
-        self.op_i32_eq();
-        self.op_br_if_nez(36);
-        self.op_local_get(2);
-        self.op_i32_const(-1);
-        self.op_i32_add();
-        self.op_i32_const(31);
-        self.op_i32_lt_u();
-        self.op_br_if_nez(10);
-        self.op_i32_const(0);
-        self.op_local_set(1);
-        self.op_local_get(2);
-        self.op_i32_const(32);
-        self.op_i32_gt_u();
-        self.op_br_if_nez(19);
-        self.op_i32_const(0);
-        self.op_local_set(5);
-        self.op_br(25);
-        self.op_local_get(5);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_get(7);
-        self.op_i32_const(0);
-        self.op_local_get(7);
-        self.op_i32_sub();
-        self.op_i32_shr_u();
-        self.op_i32_or();
-        self.op_local_set(5);
-        self.op_local_get(6);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_set(1);
-        self.op_br(10);
-        self.op_local_get(6);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_set(5);
-        self.op_br(5);
-        self.op_i32_const(0);
-        self.op_local_set(1);
-        self.op_local_get(6);
-        self.op_local_set(5);
-        self.op_local_get(5);
-        self.op_i32_const(0);
-        self.op_i32_const(32);
-        self.op_i32_const(0);
-        self.op_local_get(2);
-        self.op_i32_const(63);
-        self.op_i32_and();
-        self.op_local_set(2);
-        self.op_local_get(2);
-        self.op_br_if_eqz(32);
-        self.op_local_get(2);
-        self.op_i32_const(31);
-        self.op_i32_gt_u();
-        self.op_br_if_eqz(10);
-        self.op_local_get(4);
-        self.op_local_get(3);
-        self.op_i32_const(32);
-        self.op_i32_sub();
-        self.op_i32_shl();
-        self.op_local_set(3);
-        self.op_i32_const(0);
-        self.op_local_set(4);
-        self.op_br(19);
-        self.op_local_get(4);
-        self.op_local_get(3);
-        self.op_i32_shl();
-        self.op_local_set(4);
-        self.op_local_get(3);
-        self.op_local_get(3);
-        self.op_i32_shl();
-        self.op_local_set(3);
-        self.op_local_get(4);
-        self.op_i32_const(32);
-        self.op_local_get(4);
-        self.op_i32_const(31);
-        self.op_i32_and();
-        self.op_i32_sub();
-        self.op_i32_shr_u();
-        self.op_local_get(4);
-        self.op_i32_or();
-        self.op_local_set(3);
-        self.op_drop();
-        self.op_drop();
-        self.op_local_get(3);
-        self.op_i32_const(0);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_set(6);
-        self.op_local_set(6);
-        self.op_drop();
-        self.op_drop();
-        self.op_drop();
-        self.op_drop();
-    }
-
-    /// Max stack height: 21
-    pub fn op_i64_shr_s(&mut self) {
-        self.op_i32_const(0);
-        self.op_i32_const(0);
-        self.op_local_get(4);
-        self.op_i32_const(63);
-        self.op_i32_and();
-        self.op_local_tee(3);
-        self.op_br_if_nez(4);
-        self.op_local_get(5);
-        self.op_local_set(1);
-        self.op_br(49);
-        self.op_local_get(2);
-        self.op_i32_const(32);
-        self.op_i32_eq();
-        self.op_br_if_nez(24);
-        self.op_local_get(2);
-        self.op_i32_const(-1);
-        self.op_i32_add();
-        self.op_i32_const(31);
-        self.op_i32_lt_u();
-        self.op_br_if_nez(25);
-        self.op_i32_const(0);
-        self.op_local_set(1);
-        self.op_i32_const(0);
-        self.op_local_set(6);
-        self.op_local_get(2);
-        self.op_i32_const(32);
-        self.op_i32_le_u();
-        self.op_br_if_nez(31);
-        self.op_local_get(5);
-        self.op_local_get(5);
-        self.op_i32_shr_s();
-        self.op_local_set(6);
-        self.op_local_get(5);
-        self.op_i32_const(31);
-        self.op_i32_shr_s();
-        self.op_local_set(1);
-        self.op_br(22);
-        self.op_local_get(5);
-        self.op_i32_const(31);
-        self.op_i32_shr_s();
-        self.op_local_set(1);
-        self.op_local_get(5);
-        self.op_local_set(6);
-        self.op_br(15);
-        self.op_local_get(6);
-        self.op_local_get(5);
-        self.op_i32_shr_u();
-        self.op_local_get(6);
-        self.op_i32_const(0);
-        self.op_local_get(7);
-        self.op_i32_sub();
-        self.op_i32_shl();
-        self.op_i32_or();
-        self.op_local_set(6);
-        self.op_local_get(5);
-        self.op_local_get(5);
-        self.op_i32_shr_s();
-        self.op_local_set(1);
+        self.op_i32_and(); // [n, x_hi, x_lo]
         self.op_local_get(1);
-        self.op_i32_const(0);
         self.op_i32_const(32);
-        self.op_i32_const(0);
-        self.op_i32_const(0);
-        self.op_i32_const(0);
-        self.op_local_get(4);
-        self.op_i32_const(63);
-        self.op_i32_and();
-        self.op_local_tee(3);
-        self.op_br_if_nez(4);
-        self.op_local_get(6);
-        self.op_local_set(1);
-        self.op_br(44);
-        self.op_local_get(2);
-        self.op_i32_const(32);
-        self.op_i32_eq();
-        self.op_br_if_nez(36);
-        self.op_local_get(2);
-        self.op_i32_const(-1);
-        self.op_i32_add();
-        self.op_i32_const(31);
         self.op_i32_lt_u();
-        self.op_br_if_nez(10);
-        self.op_i32_const(0);
-        self.op_local_set(1);
-        self.op_local_get(2);
-        self.op_i32_const(32);
-        self.op_i32_gt_u();
-        self.op_br_if_nez(19);
-        self.op_i32_const(0);
-        self.op_local_set(5);
-        self.op_br(25);
-        self.op_local_get(5);
-        self.op_local_get(5);
+        self.op_br_if_eqz(19); // n in 32..63
+                               // n in 0..31: res_hi = (x_hi << n) | ((x_lo >> 1) >> (31 - n)); res_lo = x_lo << n
+        self.op_local_get(2); // x_hi
+        self.op_local_get(2); // n
         self.op_i32_shl();
-        self.op_local_get(7);
-        self.op_i32_const(0);
-        self.op_local_get(7);
-        self.op_i32_sub();
+        self.op_local_get(4); // x_lo
+        self.op_i32_const(1);
         self.op_i32_shr_u();
-        self.op_i32_or();
-        self.op_local_set(5);
-        self.op_local_get(6);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_set(1);
-        self.op_br(10);
-        self.op_local_get(6);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_set(5);
-        self.op_br(5);
-        self.op_i32_const(0);
-        self.op_local_set(1);
-        self.op_local_get(6);
-        self.op_local_set(5);
-        self.op_local_get(5);
-        self.op_i32_const(0);
-        self.op_i32_const(32);
-        self.op_i32_const(0);
-        self.op_local_get(2);
-        self.op_i32_const(63);
-        self.op_i32_and();
-        self.op_local_set(2);
-        self.op_local_get(2);
-        self.op_br_if_eqz(32);
-        self.op_local_get(2);
         self.op_i32_const(31);
-        self.op_i32_gt_u();
-        self.op_br_if_eqz(10);
-        self.op_local_get(4);
-        self.op_local_get(3);
-        self.op_i32_const(32);
-        self.op_i32_sub();
-        self.op_i32_shl();
-        self.op_local_set(3);
-        self.op_i32_const(0);
-        self.op_local_set(4);
-        self.op_br(19);
-        self.op_local_get(4);
-        self.op_local_get(3);
-        self.op_i32_shl();
-        self.op_local_set(4);
-        self.op_local_get(3);
-        self.op_local_get(3);
-        self.op_i32_shl();
-        self.op_local_set(3);
-        self.op_local_get(4);
-        self.op_i32_const(32);
-        self.op_local_get(4);
-        self.op_i32_const(31);
-        self.op_i32_and();
+        self.op_local_get(4); // n
         self.op_i32_sub();
         self.op_i32_shr_u();
-        self.op_local_get(4);
-        self.op_i32_or();
-        self.op_local_set(3);
+        self.op_i32_or(); // res_hi
+        self.op_local_set(2); // [n, res_hi, x_lo]
+        self.op_local_get(3); // x_lo
+        self.op_local_get(2); // n
+        self.op_i32_shl(); // res_lo
+        self.op_local_set(3); // [n, res_hi, res_lo]
         self.op_drop();
-        self.op_drop();
-        self.op_local_get(3);
-        self.op_i32_const(0);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_set(6);
-        self.op_local_set(6);
-        self.op_drop();
-        self.op_drop();
-        self.op_drop();
-        self.op_drop();
-        self.op_local_get(8);
-        self.op_i32_const(0);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_set(6);
-        self.op_local_set(6);
-        self.op_drop();
-        self.op_drop();
-        self.op_drop();
-        self.op_drop();
-    }
-
-    /// Max stack height: 21
-    pub fn op_i64_shr_u(&mut self) {
-        self.op_i32_const(0);
-        self.op_i32_const(0);
-        self.op_local_get(4);
-        self.op_i32_const(63);
-        self.op_i32_and();
-        self.op_local_tee(3);
-        self.op_br_if_nez(6);
-        self.op_local_get(5);
-        self.op_local_set(1);
-        self.op_local_get(6);
-        self.op_local_set(5);
-        self.op_br(42);
-        self.op_local_get(2);
-        self.op_i32_const(32);
-        self.op_i32_eq();
-        self.op_br_if_nez(36);
-        self.op_local_get(2);
-        self.op_i32_const(-1);
-        self.op_i32_add();
-        self.op_i32_const(31);
-        self.op_i32_lt_u();
-        self.op_br_if_nez(10);
-        self.op_i32_const(0);
-        self.op_local_set(1);
-        self.op_local_get(2);
-        self.op_i32_const(32);
-        self.op_i32_gt_u();
-        self.op_br_if_nez(19);
-        self.op_i32_const(0);
-        self.op_local_set(5);
-        self.op_br(23);
-        self.op_local_get(5);
-        self.op_local_get(5);
-        self.op_i32_shr_u();
-        self.op_local_set(1);
-        self.op_local_get(6);
-        self.op_local_get(5);
-        self.op_i32_shr_u();
-        self.op_local_get(6);
-        self.op_i32_const(0);
-        self.op_local_get(7);
-        self.op_i32_sub();
-        self.op_i32_shl();
-        self.op_i32_or();
-        self.op_local_set(5);
         self.op_br(8);
-        self.op_local_get(5);
-        self.op_local_get(5);
-        self.op_i32_shr_u();
-        self.op_local_set(5);
-        self.op_br(3);
+        // n in 32..63: res_hi = x_lo << (n - 32); res_lo = 0
+        self.op_local_get(3); // x_lo
+        self.op_local_get(2); // n
+        self.op_i32_shl(); // res_hi
+        self.op_local_set(2); // [n, res_hi, x_lo]
         self.op_i32_const(0);
-        self.op_local_set(1);
+        self.op_local_set(3); // [n, res_hi, 0]
+        self.op_drop();
+    }
+
+    /// Max stack height: 3
+    pub fn op_i64_shr_s(&mut self) {
+        // [n_hi, n_lo, x_hi, x_lo]
+        self.op_drop();
+        self.op_i32_const(63);
+        self.op_i32_and(); // [n, x_hi, x_lo]
         self.op_local_get(1);
-        self.op_i32_const(0);
         self.op_i32_const(32);
-        self.op_i32_const(0);
-        self.op_local_get(2);
-        self.op_i32_const(63);
-        self.op_i32_and();
-        self.op_local_set(2);
-        self.op_local_get(2);
-        self.op_br_if_eqz(32);
-        self.op_local_get(2);
-        self.op_i32_const(31);
-        self.op_i32_gt_u();
-        self.op_br_if_eqz(10);
-        self.op_local_get(4);
-        self.op_local_get(3);
-        self.op_i32_const(32);
-        self.op_i32_sub();
-        self.op_i32_shl();
-        self.op_local_set(3);
-        self.op_i32_const(0);
-        self.op_local_set(4);
-        self.op_br(19);
-        self.op_local_get(4);
-        self.op_local_get(3);
-        self.op_i32_shl();
-        self.op_local_set(4);
-        self.op_local_get(3);
-        self.op_local_get(3);
-        self.op_i32_shl();
-        self.op_local_set(3);
-        self.op_local_get(4);
-        self.op_i32_const(32);
-        self.op_local_get(4);
-        self.op_i32_const(31);
-        self.op_i32_and();
-        self.op_i32_sub();
+        self.op_i32_lt_u();
+        self.op_br_if_eqz(19); // n in 32..63
+                               // n in 0..31: res_lo = (x_lo >> n) | ((x_hi << 1) << (31 - n)); res_hi = x_hi >>s n
+        self.op_local_get(3); // x_lo
+        self.op_local_get(2); // n
         self.op_i32_shr_u();
-        self.op_local_get(4);
-        self.op_i32_or();
-        self.op_local_set(3);
+        self.op_local_get(3); // x_hi
+        self.op_i32_const(1);
+        self.op_i32_shl();
+        self.op_i32_const(31);
+        self.op_local_get(4); // n
+        self.op_i32_sub();
+        self.op_i32_shl();
+        self.op_i32_or(); // res_lo
+        self.op_local_set(3); // [n, x_hi, res_lo]
+        self.op_local_get(2); // x_hi
+        self.op_local_get(2); // n
+        self.op_i32_shr_s(); // res_hi
+        self.op_local_set(2); // [n, res_hi, res_lo]
         self.op_drop();
-        self.op_drop();
-        self.op_local_get(7);
-        self.op_i32_const(0);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_set(6);
-        self.op_local_set(6);
-        self.op_drop();
-        self.op_drop();
-        self.op_drop();
+        self.op_br(10);
+        // n in 32..63: res_lo = x_hi >>s (n - 32); res_hi = x_hi >>s 31
+        self.op_local_get(2); // x_hi
+        self.op_local_get(2); // n
+        self.op_i32_shr_s(); // res_lo
+        self.op_local_set(3); // [n, x_hi, res_lo]
+        self.op_local_get(2); // x_hi
+        self.op_i32_const(31);
+        self.op_i32_shr_s(); // res_hi
+        self.op_local_set(2); // [n, res_hi, res_lo]
         self.op_drop();
     }
 
-    /// Max stack height: 16
+    /// Max stack height: 3
+    pub fn op_i64_shr_u(&mut self) {
+        // [n_hi, n_lo, x_hi, x_lo]
+        self.op_drop();
+        self.op_i32_const(63);
+        self.op_i32_and(); // [n, x_hi, x_lo]
+        self.op_local_get(1);
+        self.op_i32_const(32);
+        self.op_i32_lt_u();
+        self.op_br_if_eqz(19); // n in 32..63
+                               // n in 0..31: res_lo = (x_lo >> n) | ((x_hi << 1) << (31 - n)); res_hi = x_hi >> n
+        self.op_local_get(3); // x_lo
+        self.op_local_get(2); // n
+        self.op_i32_shr_u();
+        self.op_local_get(3); // x_hi
+        self.op_i32_const(1);
+        self.op_i32_shl();
+        self.op_i32_const(31);
+        self.op_local_get(4); // n
+        self.op_i32_sub();
+        self.op_i32_shl();
+        self.op_i32_or(); // res_lo
+        self.op_local_set(3); // [n, x_hi, res_lo]
+        self.op_local_get(2); // x_hi
+        self.op_local_get(2); // n
+        self.op_i32_shr_u(); // res_hi
+        self.op_local_set(2); // [n, res_hi, res_lo]
+        self.op_drop();
+        self.op_br(8);
+        // n in 32..63: res_lo = x_hi >> (n - 32); res_hi = 0
+        self.op_local_get(2); // x_hi
+        self.op_local_get(2); // n
+        self.op_i32_shr_u(); // res_lo
+        self.op_local_set(3); // [n, x_hi, res_lo]
+        self.op_i32_const(0);
+        self.op_local_set(2); // [n, 0, res_lo]
+        self.op_drop();
+    }
+
+    /// Max stack height: 4
     pub fn op_i64_rotl(&mut self) {
-        self.op_i32_const(0);
-        self.op_i32_const(0);
-        self.op_local_get(4);
+        // [n_hi, n_lo, x_hi, x_lo]
+        self.op_drop();
         self.op_i32_const(63);
-        self.op_i32_and();
-        self.op_local_tee(3);
-        self.op_br_if_nez(4);
-        self.op_local_get(5);
-        self.op_local_set(2);
-        self.op_br(53);
-        self.op_local_get(2);
+        self.op_i32_and(); // [n, x_hi, x_lo]
+        self.op_local_get(1);
         self.op_i32_const(32);
         self.op_i32_lt_u();
-        self.op_br_if_nez(10);
-        self.op_local_get(2);
-        self.op_i32_const(32);
-        self.op_i32_ne();
-        self.op_br_if_nez(26);
-        self.op_local_get(6);
-        self.op_local_set(2);
-        self.op_local_get(5);
-        self.op_local_set(6);
-        self.op_br(40);
-        self.op_local_get(5);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_get(7);
-        self.op_i32_const(0);
-        self.op_local_get(7);
-        self.op_i32_sub();
-        self.op_local_tee(4);
-        self.op_i32_shr_u();
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_get(6);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_get(6);
+        self.op_br_if_nez(5); // n in 0..31: skip the limb swap
+                              // rotl by n in 32..63 == swap limbs, then rotl by n - 32 (shifts self-mask below)
         self.op_local_get(3);
-        self.op_i32_shr_u();
-        self.op_i32_or();
-        self.op_local_set(6);
-        self.op_br(20);
-        self.op_local_get(6);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_get(6);
-        self.op_i32_const(0);
-        self.op_local_get(7);
-        self.op_i32_sub();
-        self.op_local_tee(4);
-        self.op_i32_shr_u();
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_get(5);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_get(7);
         self.op_local_get(3);
-        self.op_i32_shr_u();
-        self.op_i32_or();
-        self.op_local_set(6);
-        self.op_local_get(2);
-        self.op_i32_const(0);
-        self.op_i32_const(32);
-        self.op_i32_const(0);
-        self.op_i32_const(0);
-        self.op_i32_const(0);
-        self.op_local_get(4);
-        self.op_i32_const(63);
-        self.op_i32_and();
-        self.op_local_tee(3);
-        self.op_br_if_nez(4);
-        self.op_local_get(6);
-        self.op_local_set(1);
-        self.op_br(44);
-        self.op_local_get(2);
-        self.op_i32_const(32);
-        self.op_i32_eq();
-        self.op_br_if_nez(36);
-        self.op_local_get(2);
-        self.op_i32_const(-1);
-        self.op_i32_add();
-        self.op_i32_const(31);
-        self.op_i32_lt_u();
-        self.op_br_if_nez(10);
-        self.op_i32_const(0);
-        self.op_local_set(1);
-        self.op_local_get(2);
-        self.op_i32_const(32);
-        self.op_i32_gt_u();
-        self.op_br_if_nez(19);
-        self.op_i32_const(0);
-        self.op_local_set(5);
-        self.op_br(25);
-        self.op_local_get(5);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_get(7);
-        self.op_i32_const(0);
-        self.op_local_get(7);
-        self.op_i32_sub();
-        self.op_i32_shr_u();
-        self.op_i32_or();
-        self.op_local_set(5);
-        self.op_local_get(6);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_set(1);
-        self.op_br(10);
-        self.op_local_get(6);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_set(5);
-        self.op_br(5);
-        self.op_i32_const(0);
-        self.op_local_set(1);
-        self.op_local_get(6);
-        self.op_local_set(5);
-        self.op_local_get(5);
-        self.op_i32_const(0);
-        self.op_i32_const(32);
-        self.op_i32_const(0);
-        self.op_local_get(2);
-        self.op_i32_const(63);
-        self.op_i32_and();
-        self.op_local_set(2);
-        self.op_local_get(2);
-        self.op_br_if_eqz(32);
-        self.op_local_get(2);
-        self.op_i32_const(31);
-        self.op_i32_gt_u();
-        self.op_br_if_eqz(10);
-        self.op_local_get(4);
-        self.op_local_get(3);
-        self.op_i32_const(32);
-        self.op_i32_sub();
-        self.op_i32_shl();
-        self.op_local_set(3);
-        self.op_i32_const(0);
         self.op_local_set(4);
-        self.op_br(19);
-        self.op_local_get(4);
-        self.op_local_get(3);
+        self.op_local_set(2); // [n, X, Y]: X = hi limb source, Y = lo limb source
+                              // res_hi = (X << n) | ((Y >> 1) >> (31 - n))
+        self.op_local_get(2); // X
+        self.op_local_get(2); // n
         self.op_i32_shl();
-        self.op_local_set(4);
-        self.op_local_get(3);
-        self.op_local_get(3);
-        self.op_i32_shl();
-        self.op_local_set(3);
-        self.op_local_get(4);
-        self.op_i32_const(32);
-        self.op_local_get(4);
+        self.op_local_get(4); // Y
+        self.op_i32_const(1);
+        self.op_i32_shr_u();
         self.op_i32_const(31);
-        self.op_i32_and();
+        self.op_local_get(4); // n
         self.op_i32_sub();
         self.op_i32_shr_u();
-        self.op_local_get(4);
-        self.op_i32_or();
-        self.op_local_set(3);
-        self.op_drop();
-        self.op_drop();
-        self.op_local_get(3);
-        self.op_i32_const(0);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_set(6);
-        self.op_local_set(6);
-        self.op_drop();
-        self.op_drop();
-        self.op_drop();
-        self.op_drop();
-        self.op_local_get(8);
-        self.op_i32_const(0);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_set(6);
-        self.op_local_set(6);
-        self.op_drop();
-        self.op_drop();
-        self.op_drop();
+        self.op_i32_or(); // [res_hi, n, X, Y]
+                          // res_lo = (Y << n) | ((X >> 1) >> (31 - n))
+        self.op_local_get(4); // Y
+        self.op_local_get(3); // n
+        self.op_i32_shl();
+        self.op_local_get(4); // X
+        self.op_i32_const(1);
+        self.op_i32_shr_u();
+        self.op_i32_const(31);
+        self.op_local_get(5); // n
+        self.op_i32_sub();
+        self.op_i32_shr_u();
+        self.op_i32_or(); // [res_lo, res_hi, n, X, Y]
+        self.op_local_set(4); // [res_hi, n, X, res_lo]
+        self.op_local_set(2); // [n, res_hi, res_lo]
         self.op_drop();
     }
 
-    /// Max stack height: 16
+    /// Max stack height: 4
     pub fn op_i64_rotr(&mut self) {
-        self.op_i32_const(0);
-        self.op_i32_const(0);
-        self.op_local_get(4);
+        // [n_hi, n_lo, x_hi, x_lo]
+        self.op_drop();
         self.op_i32_const(63);
-        self.op_i32_and();
-        self.op_local_tee(3);
-        self.op_br_if_nez(4);
-        self.op_local_get(5);
-        self.op_local_set(2);
-        self.op_br(55);
-        self.op_local_get(2);
+        self.op_i32_and(); // [n, x_hi, x_lo]
+        self.op_local_get(1);
         self.op_i32_const(32);
-        self.op_i32_ne();
-        self.op_br_if_nez(6);
-        self.op_local_get(6);
-        self.op_local_set(2);
-        self.op_local_get(5);
-        self.op_local_set(6);
-        self.op_br(46);
-        self.op_local_get(2);
-        self.op_i32_const(-1);
-        self.op_i32_add();
-        self.op_i32_const(31);
         self.op_i32_lt_u();
-        self.op_br_if_nez(21);
-        self.op_local_get(6);
-        self.op_local_get(5);
-        self.op_i32_shr_u();
-        self.op_local_get(6);
-        self.op_i32_const(0);
-        self.op_local_get(7);
-        self.op_i32_sub();
-        self.op_local_tee(4);
-        self.op_i32_shl();
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_get(5);
-        self.op_local_get(5);
-        self.op_i32_shr_u();
-        self.op_local_get(7);
+        self.op_br_if_nez(5); // n in 0..31: skip the limb swap
+                              // rotr by n in 32..63 == swap limbs, then rotr by n - 32 (shifts self-mask below)
         self.op_local_get(3);
-        self.op_i32_shl();
-        self.op_i32_or();
-        self.op_local_set(6);
-        self.op_br(20);
-        self.op_local_get(5);
-        self.op_local_get(5);
-        self.op_i32_shr_u();
-        self.op_local_get(7);
-        self.op_i32_const(0);
-        self.op_local_get(7);
-        self.op_i32_sub();
-        self.op_local_tee(4);
-        self.op_i32_shl();
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_get(6);
-        self.op_local_get(5);
-        self.op_i32_shr_u();
-        self.op_local_get(6);
         self.op_local_get(3);
-        self.op_i32_shl();
-        self.op_i32_or();
-        self.op_local_set(6);
-        self.op_local_get(2);
-        self.op_i32_const(0);
-        self.op_i32_const(32);
-        self.op_i32_const(0);
-        self.op_i32_const(0);
-        self.op_i32_const(0);
-        self.op_local_get(4);
-        self.op_i32_const(63);
-        self.op_i32_and();
-        self.op_local_tee(3);
-        self.op_br_if_nez(4);
-        self.op_local_get(6);
-        self.op_local_set(1);
-        self.op_br(44);
-        self.op_local_get(2);
-        self.op_i32_const(32);
-        self.op_i32_eq();
-        self.op_br_if_nez(36);
-        self.op_local_get(2);
-        self.op_i32_const(-1);
-        self.op_i32_add();
-        self.op_i32_const(31);
-        self.op_i32_lt_u();
-        self.op_br_if_nez(10);
-        self.op_i32_const(0);
-        self.op_local_set(1);
-        self.op_local_get(2);
-        self.op_i32_const(32);
-        self.op_i32_gt_u();
-        self.op_br_if_nez(19);
-        self.op_i32_const(0);
-        self.op_local_set(5);
-        self.op_br(25);
-        self.op_local_get(5);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_get(7);
-        self.op_i32_const(0);
-        self.op_local_get(7);
-        self.op_i32_sub();
-        self.op_i32_shr_u();
-        self.op_i32_or();
-        self.op_local_set(5);
-        self.op_local_get(6);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_set(1);
-        self.op_br(10);
-        self.op_local_get(6);
-        self.op_local_get(5);
-        self.op_i32_shl();
-        self.op_local_set(5);
-        self.op_br(5);
-        self.op_i32_const(0);
-        self.op_local_set(1);
-        self.op_local_get(6);
-        self.op_local_set(5);
-        self.op_local_get(5);
-        self.op_i32_const(0);
-        self.op_i32_const(32);
-        self.op_i32_const(0);
-        self.op_local_get(2);
-        self.op_i32_const(63);
-        self.op_i32_and();
-        self.op_local_set(2);
-        self.op_local_get(2);
-        self.op_br_if_eqz(32);
-        self.op_local_get(2);
-        self.op_i32_const(31);
-        self.op_i32_gt_u();
-        self.op_br_if_eqz(10);
-        self.op_local_get(4);
-        self.op_local_get(3);
-        self.op_i32_const(32);
-        self.op_i32_sub();
-        self.op_i32_shl();
-        self.op_local_set(3);
-        self.op_i32_const(0);
         self.op_local_set(4);
-        self.op_br(19);
-        self.op_local_get(4);
-        self.op_local_get(3);
-        self.op_i32_shl();
-        self.op_local_set(4);
-        self.op_local_get(3);
-        self.op_local_get(3);
-        self.op_i32_shl();
-        self.op_local_set(3);
-        self.op_local_get(4);
-        self.op_i32_const(32);
-        self.op_local_get(4);
-        self.op_i32_const(31);
-        self.op_i32_and();
-        self.op_i32_sub();
+        self.op_local_set(2); // [n, X, Y]: X = hi limb source, Y = lo limb source
+                              // res_hi = (X >> n) | ((Y << 1) << (31 - n))
+        self.op_local_get(2); // X
+        self.op_local_get(2); // n
         self.op_i32_shr_u();
-        self.op_local_get(4);
-        self.op_i32_or();
-        self.op_local_set(3);
-        self.op_drop();
-        self.op_drop();
-        self.op_local_get(3);
-        self.op_i32_const(0);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_set(6);
-        self.op_local_set(6);
-        self.op_drop();
-        self.op_drop();
-        self.op_drop();
-        self.op_drop();
-        self.op_local_get(8);
-        self.op_i32_const(0);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_set(6);
-        self.op_local_set(6);
-        self.op_drop();
-        self.op_drop();
-        self.op_drop();
+        self.op_local_get(4); // Y
+        self.op_i32_const(1);
+        self.op_i32_shl();
+        self.op_i32_const(31);
+        self.op_local_get(4); // n
+        self.op_i32_sub();
+        self.op_i32_shl();
+        self.op_i32_or(); // [res_hi, n, X, Y]
+                          // res_lo = (Y >> n) | ((X << 1) << (31 - n))
+        self.op_local_get(4); // Y
+        self.op_local_get(3); // n
+        self.op_i32_shr_u();
+        self.op_local_get(4); // X
+        self.op_i32_const(1);
+        self.op_i32_shl();
+        self.op_i32_const(31);
+        self.op_local_get(5); // n
+        self.op_i32_sub();
+        self.op_i32_shl();
+        self.op_i32_or(); // [res_lo, res_hi, n, X, Y]
+        self.op_local_set(4); // [res_hi, n, X, res_lo]
+        self.op_local_set(2); // [n, res_hi, res_lo]
         self.op_drop();
     }
 }

--- a/tests/snippets.rs
+++ b/tests/snippets.rs
@@ -732,6 +732,69 @@ fn test_i64_shl() {
     test_case_u64(0x7FFFFFFFFFFFFFFF, 1);
 }
 
+/// Exhaustive shift-amount sweep for every shift/rotate op: all amounts 0..=127 (covering the
+/// modulo-64 masking) plus amounts with a non-zero high limb, against native u64 semantics.
+#[test]
+fn test_i64_shift_rotate_exhaustive() {
+    let patterns: [u64; 10] = [
+        0,
+        1,
+        u64::MAX,
+        0x8000000000000000,
+        0x0000000180000001,
+        0x123456789ABCDEF0,
+        0xAAAAAAAAAAAAAAAA,
+        0x00000000FFFFFFFF,
+        0xFFFFFFFF00000000,
+        0xDEADBEEFCAFEBABE,
+    ];
+    type ShiftOp = (fn(&mut InstructionSet), fn(u64, u32) -> u64, u32);
+    let ops: [ShiftOp; 5] = [
+        (
+            InstructionSet::op_i64_shl,
+            |a, n| a.wrapping_shl(n),
+            InstructionSet::MSH_I64_SHL,
+        ),
+        (
+            InstructionSet::op_i64_shr_u,
+            |a, n| a.wrapping_shr(n),
+            InstructionSet::MSH_I64_SHR_U,
+        ),
+        (
+            InstructionSet::op_i64_shr_s,
+            |a, n| (a as i64).wrapping_shr(n) as u64,
+            InstructionSet::MSH_I64_SHR_S,
+        ),
+        (
+            InstructionSet::op_i64_rotl,
+            |a, n| a.rotate_left(n & 0x3F),
+            InstructionSet::MSH_I64_ROTL,
+        ),
+        (
+            InstructionSet::op_i64_rotr,
+            |a, n| a.rotate_right(n & 0x3F),
+            InstructionSet::MSH_I64_ROTR,
+        ),
+    ];
+    for (emitter, native, msh) in ops {
+        let mut is = InstructionSet::new();
+        emitter(&mut is);
+        let test_case = |a: u64, b: u64| {
+            let c = native(a, (b & 0x3F) as u32);
+            run_binary_test_case(&is, a, b, c, msh).unwrap();
+        };
+        for a in patterns {
+            for b in 0..=127u64 {
+                test_case(a, b);
+            }
+            // the high limb of the shift amount must be ignored
+            test_case(a, 0x0000000100000005);
+            test_case(a, 0xFFFFFFFF00000021);
+            test_case(a, u64::MAX);
+        }
+    }
+}
+
 #[test]
 fn test_i64_clz() {
     let mut is = InstructionSet::new();

--- a/tests/value-stack-api.rs
+++ b/tests/value-stack-api.rs
@@ -1,0 +1,220 @@
+//! Unit tests for the [`ValueStack`] accounting API.
+//!
+//! `tests/value-stack-bounds.rs` covers the same guarantees as observed through the interpreter.
+//! This file drives the stack directly, pinning down the bookkeeping the compiler relies on when
+//! it sizes a `StackCheck`: the height watermark behind the `MSH_*` constants, the suppressed
+//! out-of-bounds accesses, and the push/pop/drop arithmetic around the stack pointer.
+
+use rwasm::{TrapCode, UntypedValue, ValueStack};
+
+fn val(x: u32) -> UntypedValue {
+    UntypedValue::from(x)
+}
+
+fn stack_with(values: &[u32]) -> ValueStack {
+    let mut stack = ValueStack::default();
+    for &v in values {
+        stack.push(val(v));
+    }
+    stack
+}
+
+#[test]
+fn empty_stack_does_not_allocate_and_reports_zero_height() {
+    let stack = ValueStack::empty();
+    assert!(stack.is_empty());
+    assert_eq!(stack.max_stack_height(), 0);
+    assert!(!stack.is_out_of_bounds());
+}
+
+#[test]
+fn push_and_pop_round_trip_in_lifo_order() {
+    let mut stack = stack_with(&[1, 2, 3]);
+    assert!(!stack.is_empty());
+    assert_eq!(stack.pop(), val(3));
+    assert_eq!(stack.pop(), val(2));
+    assert_eq!(stack.pop(), val(1));
+    assert!(stack.is_empty());
+    assert!(!stack.is_out_of_bounds());
+}
+
+/// The watermark is what `InstructionSet::MSH_*` is compared against in `tests/snippets.rs`. It is
+/// fed by `sync_stack_ptr`, which is how the interpreter publishes the height it reached, and it
+/// records the peak rather than the current height.
+#[test]
+fn max_stack_height_records_the_peak_not_the_current_height() {
+    let mut stack = ValueStack::default();
+    stack.reserve(8).unwrap();
+    let base = stack.stack_ptr();
+
+    stack.sync_stack_ptr(base.into_add(4));
+    assert_eq!(stack.max_stack_height(), 4);
+
+    stack.sync_stack_ptr(base.into_add(2));
+    assert_eq!(
+        stack.max_stack_height(),
+        4,
+        "descending must not lower the peak"
+    );
+
+    stack.sync_stack_ptr(base.into_add(6));
+    assert_eq!(stack.max_stack_height(), 6, "exceeding the peak raises it");
+}
+
+#[test]
+fn popping_an_empty_stack_yields_zero_and_flags_out_of_bounds() {
+    let mut stack = ValueStack::default();
+    assert_eq!(stack.pop(), UntypedValue::default());
+    assert!(stack.is_out_of_bounds());
+}
+
+#[test]
+fn dropping_more_than_the_stack_holds_clamps_and_flags_out_of_bounds() {
+    let mut stack = stack_with(&[1, 2]);
+    stack.drop(1);
+    assert!(!stack.is_out_of_bounds());
+    stack.drop(5);
+    assert!(stack.is_empty());
+    assert!(stack.is_out_of_bounds());
+}
+
+#[test]
+fn peeking_deeper_than_the_stack_returns_empty_and_flags_out_of_bounds() {
+    let mut stack = stack_with(&[1, 2, 3]);
+    assert_eq!(stack.peek_as_slice_mut(2), &[val(2), val(3)]);
+    assert!(!stack.is_out_of_bounds());
+    assert!(stack.peek_as_slice_mut(9).is_empty());
+    assert!(stack.is_out_of_bounds());
+}
+
+#[test]
+fn peeked_slice_writes_back_into_the_stack() {
+    let mut stack = stack_with(&[1, 2, 3]);
+    stack.peek_as_slice_mut(2)[0] = val(42);
+    assert_eq!(stack.pop(), val(3));
+    assert_eq!(stack.pop(), val(42));
+}
+
+#[test]
+fn reset_clears_the_contents_the_watermark_and_the_out_of_bounds_flag() {
+    let mut stack = stack_with(&[1, 2, 3]);
+    stack.pop();
+    stack.pop();
+    stack.pop();
+    stack.pop(); // underflow, sets the flag
+    assert!(stack.is_out_of_bounds());
+
+    stack.reset();
+    assert!(stack.is_empty());
+    assert_eq!(stack.max_stack_height(), 0);
+    assert!(!stack.is_out_of_bounds());
+}
+
+#[test]
+fn drain_returns_every_entry_and_empties_the_stack() {
+    let mut stack = stack_with(&[7, 8, 9]);
+    assert_eq!(stack.drain(), &[val(7), val(8), val(9)]);
+    assert!(stack.is_empty());
+}
+
+#[test]
+fn extend_zeros_appends_default_cells_above_the_live_entries() {
+    let mut stack = stack_with(&[1]);
+    stack.reserve(4).unwrap();
+    stack.extend_zeros(3);
+    assert_eq!(stack.dump_stack().len(), 4);
+    assert_eq!(stack.pop(), UntypedValue::default());
+    assert_eq!(stack.pop(), UntypedValue::default());
+    assert_eq!(stack.pop(), UntypedValue::default());
+    assert_eq!(stack.pop(), val(1));
+}
+
+#[test]
+fn reserving_beyond_the_maximum_length_reports_stack_overflow() {
+    let mut stack = ValueStack::new(4, 8);
+    assert_eq!(stack.reserve(4), Ok(()));
+    assert_eq!(stack.reserve(usize::MAX), Err(TrapCode::StackOverflow));
+    assert_eq!(stack.reserve(9), Err(TrapCode::StackOverflow));
+}
+
+#[test]
+fn dump_stack_and_as_slice_expose_the_live_entries_only() {
+    let mut stack = stack_with(&[4, 5, 6]);
+    stack.pop();
+    assert_eq!(stack.dump_stack(), vec![val(4), val(5)]);
+    assert_eq!(stack.as_slice(), &[val(4), val(5)]);
+}
+
+#[test]
+fn extend_pushes_every_item_of_the_iterator() {
+    let mut stack = ValueStack::default();
+    stack.extend([val(1), val(2), val(3)]);
+    assert_eq!(stack.dump_stack(), vec![val(1), val(2), val(3)]);
+}
+
+#[test]
+fn equality_compares_live_entries_and_ignores_the_spare_capacity() {
+    let mut a = stack_with(&[1, 2]);
+    let mut b = stack_with(&[1, 2, 3]);
+    assert_ne!(a, b);
+
+    b.pop();
+    assert_eq!(a, b, "the dropped cell must not affect equality");
+
+    a.push(val(9));
+    assert_ne!(a, b);
+}
+
+#[test]
+fn debug_output_reports_the_pointer_and_the_live_entries() {
+    let stack = stack_with(&[1, 2]);
+    let rendered = format!("{stack:?}");
+    assert!(rendered.contains("ValueStack"), "{rendered}");
+    assert!(rendered.contains("stack_ptr"), "{rendered}");
+}
+
+#[test]
+fn stack_len_is_measured_against_the_stack_pointer() {
+    let mut stack = ValueStack::new(4, 8);
+    stack.push(val(1));
+    stack.push(val(2));
+
+    let sp = stack.stack_ptr();
+    assert_eq!(stack.stack_len(sp), 2);
+    assert!(!stack.has_stack_overflowed(sp));
+    assert_eq!(stack.stack_len(sp.into_sub(2)), 0);
+}
+
+/// A pointer can never be walked past the cells it was handed: the attempt is recorded and the
+/// pointer is parked on the base, so no caller can dereference a wild address.
+#[test]
+fn advancing_a_pointer_past_its_capacity_is_refused_and_recorded() {
+    let mut stack = ValueStack::new(4, 8);
+    stack.push(val(1));
+
+    let sp = stack.stack_ptr();
+    assert!(!sp.is_out_of_bounds());
+
+    let beyond = sp.into_add(64);
+    assert!(beyond.is_out_of_bounds());
+    assert_eq!(
+        stack.stack_len(beyond),
+        0,
+        "the pointer is parked on the base"
+    );
+
+    let below = sp.into_sub(9);
+    assert!(below.is_out_of_bounds());
+}
+
+#[test]
+fn sync_stack_ptr_moves_the_height_to_the_given_pointer() {
+    let mut stack = stack_with(&[1, 2, 3]);
+    let sp = stack.stack_ptr();
+
+    stack.push(val(4));
+    assert_eq!(stack.dump_stack().len(), 4);
+
+    stack.sync_stack_ptr(sp);
+    assert_eq!(stack.dump_stack(), vec![val(1), val(2), val(3)]);
+}


### PR DESCRIPTION
Implements [FLU-1176](https://linear.app/fluentlabs-xyz/issue/FLU-1176/rewrite-i64-shiftrotate-snippet-bodies-by-hand-110-192-35-instrs-each) (sub-task of [FLU-1175](https://linear.app/fluentlabs-xyz/issue/FLU-1175/reduce-rwasm-bytecode-size-optimize-i64-isa-emitters)).

Rebased onto current `devel` (after #185 and #189); the only overlap was the `MSH_*` constant block, where the fused and/or/xor values from #189 are kept alongside the lowered shift/rotate values here.

## What

Replaces the machine-traced bodies of the five i64 shift/rotate emitters in `src/isa/bitwise.rs` with hand-written two-limb implementations. The old `shr_s`/`rotl`/`rotr` bodies embedded full duplicated copies of the `shl` algorithm (they were traced from compiled code, not written for this ISA).

| snippet | before | after |
| -- | -- | -- |
| `op_i64_shl` | 110 | 32 |
| `op_i64_shr_u` | 110 | 32 |
| `op_i64_shr_s` | 186 | 34 |
| `op_i64_rotl` | 190 | 36 |
| `op_i64_rotr` | 192 | 36 |
| **total** | **778** | **170** |

Max stack heights drop from 9/21/21/16/16 to 3/3/3/4/4, shrinking the `StackCheck` reservation in each snippet prologue (kept consistent automatically via the `MSH_*` constants used by `emit_snippets` and the inline path).

## How

Each body reduces the shift amount to `n = n_lo & 63` (high limb dropped, per wasm semantics), branches **once** on `n < 32`, and is branchless within each arm by exploiting the wasm i32 shift self-masking (`amount & 31`):

- `x << n` for `n` in 32..63 reduces to the intended `x << (n - 32)` automatically;
- `y >> (31 - n)` with negative `31 - n` reduces to `y >> (63 - n)` automatically;
- cross-limb carries use `(y >> 1) >> (31 - n)` instead of `y >> (32 - n)` so that `n = 0` yields 0 instead of a full-width shift.

Rotates conditionally swap the limbs (4 instrs) and then run one shared branchless two-limb rotate. Only existing opcodes are used — zero circuit impact (Tier 1).

## Impact

Measured with the same compilation config against current `devel`, before → after:

| asset | rwasm instrs | encoded bytes |
| -- | -- | -- |
| `nitro-verifier-stack-ub.wasm` | 290,714 → 290,252 | 2,644,825 → 2,641,557 |
| `secp256k1-stack-ub.wasm` | 26,535 → 26,379 | 2,355,093 → 2,353,981 |
| `panic-stack-ub.wasm` | 3,014 → 2,936 (−2.6%) | 64,047 → 63,491 |

Per-module fixed overhead drops ~608 instrs when all five snippets are emitted; the relative win is largest for small contracts, and executed instructions per call drop ~3–5× (relevant for proving cycles).

## Verification

- New `test_i64_shift_rotate_exhaustive` in `tests/snippets.rs`: all 5 ops × 10 bit patterns × shift amounts 0..=127 plus non-zero-high-limb amounts, against native u64 semantics (6,550 cases), with MSH assertions.
- Existing per-op snippet tests (incl. MSH checks) pass.
- Full main-crate suite passes after the rebase; wasm spec e2e suite (92 groups incl. `i64.wast`) passes; clippy clean.
- `test_nitro_verifier_*` release tests pass (real i64-heavy workload executes correctly).
