### PR TITLE
feat(isa): add I32Sub64 fused opcode and shrink op_i64_sub to 11 instrs (FLU-1180)

### DIFF
--- a/docs/opcodes.md
+++ b/docs/opcodes.md
@@ -122,6 +122,7 @@ This document is the canonical opcode inventory for `rwasm`.
 | 84 | `I32And64` | — | — |
 | 85 | `I32Or64` | — | — |
 | 86 | `I32Xor64` | — | — |
+| 87 | `I32Sub64` | — | — |
 
 ### fpu
 

--- a/src/isa/add_sub.rs
+++ b/src/isa/add_sub.rs
@@ -2,7 +2,7 @@ use crate::InstructionSet;
 
 impl InstructionSet {
     pub const MSH_I64_ADD: u32 = 4;
-    pub const MSH_I64_SUB: u32 = 8;
+    pub const MSH_I64_SUB: u32 = 4;
 
     /// Max stack height: 4
     pub fn op_i64_add(&mut self) {
@@ -19,22 +19,16 @@ impl InstructionSet {
         self.op_drop();
     }
 
-    /// Max stack height: 8
+    /// Max stack height: 4
     pub fn op_i64_sub(&mut self) {
-        // TODO(dmitry123): "looks optimizable"
         self.op_local_get(4);
         self.op_local_get(3);
-        self.op_i32_sub();
-        self.op_local_get(5);
-        self.op_local_get(4);
-        self.op_i32_lt_u();
+        self.op_i32_sub64();
         self.op_local_get(5);
         self.op_local_get(4);
         self.op_i32_sub();
-        self.op_local_get(2);
-        self.op_i32_sub();
-        self.op_local_set(5);
-        self.op_drop();
+        self.op_i32_add();
+        self.op_local_set(4);
         self.op_local_set(4);
         self.op_drop();
         self.op_drop();

--- a/src/isa/mod.rs
+++ b/src/isa/mod.rs
@@ -259,6 +259,7 @@ impl InstructionSet {
     impl_basic_opcode!(I32And64);
     impl_basic_opcode!(I32Or64);
     impl_basic_opcode!(I32Xor64);
+    impl_basic_opcode!(I32Sub64);
 
     // bulk opcodes
     impl_basic_opcode!(BulkConst(NumLocals));

--- a/src/types/opcode.rs
+++ b/src/types/opcode.rs
@@ -186,6 +186,7 @@ define_opcode_enum! {
     I32And64 => 84u32,
     I32Or64 => 85u32,
     I32Xor64 => 86u32,
+    I32Sub64 => 87u32,
 
     // fpu
     @fpu F32Load(offset: AddressOffset) => 0u32,
@@ -631,6 +632,7 @@ mod tests {
             Opcode::I32And64,
             Opcode::I32Or64,
             Opcode::I32Xor64,
+            Opcode::I32Sub64,
         ];
         for (expected, opcode) in opcodes.iter().enumerate() {
             assert_eq!(opcode.code(), expected as u32, "{opcode:#}");

--- a/src/vm/executor.rs
+++ b/src/vm/executor.rs
@@ -288,6 +288,7 @@ impl<'a, T> RwasmExecutor<'a, T> {
             I32And64 => self.visit_i32_and64(),
             I32Or64 => self.visit_i32_or64(),
             I32Xor64 => self.visit_i32_xor64(),
+            I32Sub64 => self.visit_i32_sub64(),
             BulkConst(imm) => self.visit_bulk_const(imm),
             BulkDrop(imm) => self.visit_bulk_drop(imm),
 

--- a/src/vm/executor/alu.rs
+++ b/src/vm/executor/alu.rs
@@ -99,6 +99,15 @@ impl<'a, T> RwasmExecutor<'a, T> {
         self.sp.push_i64(lhs ^ rhs);
         self.ip.add(1);
     }
+
+    pub(crate) fn visit_i32_sub64(&mut self) {
+        let (lhs, rhs) = self.sp.pop2();
+        // widened difference of the two u32 limbs: low limb holds the 32-bit
+        // difference, high limb is the borrow mask (0 or -1)
+        let res = lhs.as_u64().wrapping_sub(rhs.as_u64());
+        self.sp.push_i64(res as i64);
+        self.ip.add(1);
+    }
 }
 
 macro_rules! impl_visit_fallible_binary {

--- a/tests/snippets.rs
+++ b/tests/snippets.rs
@@ -289,6 +289,9 @@ fn test_i64_sub() {
     };
 
     test_case_u64(0, 0); // 0 - 0 = 0
+    test_case_u64(0x1234_5678_0000_0000, 0x9ABC_DEF0_0000_0000); // equal (zero) low limbs, hi differs
+    test_case_u64(0x0000_0000_8000_0000, 0x0000_0000_8000_0000); // equal limbs → 0
+    test_case_u64(0x0000_0000_0000_0001, 0x0000_0000_8000_0000); // lo_l < lo_r borrow
     test_case_u64(1, 0); // 1 - 0 = 1
     test_case_u64(0, 1); // 0 - 1 = underflow (wraps to max)
     test_case_u64(0xFFFF_FFFFu64, 1); // lo only, no borrow
@@ -302,6 +305,8 @@ fn test_i64_sub() {
     test_case_u64(0x1234_5678_9ABC_DEF0, 0x1111_1111_1111_1111);
     test_case_u64(0, u64::MAX); // 0 - max = 1 (wrap)
     test_case_u64(0xDEAD_BEEF_DEAD_BEEF, 0xCAFEBABE_CAFEBABE);
+
+    pairwise_fuzzing_test(test_case_u64, generate_random_numbers(30));
 }
 
 /// Deterministic boundary matrix for i64 comparisons: equal-hi/equal-lo pairs, sign boundaries


### PR DESCRIPTION
## What

Resolves the `TODO(dmitry123): "looks optimizable"` in `src/isa/add_sub.rs`: `op_i64_sub` was 16 instrs vs `op_i64_add`'s 11 because subtraction had no widening helper — the borrow was computed manually via `i32.lt_u` plus extra shuffles.

## How

- **New `I32Sub64` opcode** (code 87, no-arg, appended after the `I32And64`/`I32Or64`/`I32Xor64` block from #189 so existing numbering is untouched). Executor semantics mirror `I32Add64`: pop two u32 limbs, push the 64-bit widened difference — low limb is the 32-bit difference, high limb is the borrow mask (`0` or `-1`). Limb-local, same provability class as the existing `I32Add64`/`I32Mul64`, so it maps to an SP1-style zkVM chip the same way. The fixed 32-bit-aligned `bincode::config::legacy()` encoding is unchanged.
- **`op_i64_sub` rewritten symmetric to `op_i64_add`**: low-limb `I32Sub64` produces diff + borrow mask, one `I32Add` folds the mask into the high-limb subtraction. 16 → 11 instrs; `MSH_I64_SUB` drops 8 → 4.
- Wired through opcode table (+ pinned numbering test), `impl_basic_opcode!`, executor dispatch, and `docs/opcodes.md`. Display uses the existing `{:?}` fallback; `codegen_identity` hashes config only, so no change needed there. Per-op fuel is charged per wasm op at translation time, so fuel policy is unaffected.

## Impact

Measured on `tests/assets/` (default config + fluentbase import linker):

| asset | instrs before | instrs after |
|---|---|---|
| nitro-verifier | 330,841 | 330,836 (−5, one-time snippet body) |
| secp256k1 / panic | unchanged | unchanged (no i64.sub snippet) |

The main win is at runtime: every executed `i64.sub` call runs 5 fewer instructions (plus a halved max-stack-height for the snippet), and the opcode is the prerequisite two-limb-negate building block for the signed div/rem wrappers in the udivmod64 task (FLU-1177).

## Verification

- `tests/snippets.rs::test_i64_sub` — existing borrow-boundary cases (`0 − 1`, equal operands, `i64::MIN − 1` wrap, cross-limb borrow chains) now enforce the tightened MSH ≤ 4; added equal-limb / `lo_l < lo_r` cases and 30×30 pairwise random fuzzing against `u64::wrapping_sub`
- Full `cargo test` (default and `--features wasmtime`) passes
- `cargo test --release --test fluentbase test_nitro_verifier -- --ignored` (end-to-end nitro attestation verifier, i64-heavy) passes
- clippy + fmt clean

Linear: [FLU-1180](https://linear.app/fluentlabs-xyz/issue/FLU-1180/add-i32sub64-fused-opcode-borrow-producing-mirror-of-i32add64)

---

Rebased onto `devel` after #189 landed `I32And64`/`I32Or64`/`I32Xor64` at codes 84–86; `I32Sub64` moved to 87. Full suite, nitro e2e, and clippy re-verified on the rebased tree.
