### PR TITLE
perf(isa): fuse i64.and/or/xor into I32And64/I32Or64/I32Xor64 opcodes

### DIFF
--- a/docs/opcodes.md
+++ b/docs/opcodes.md
@@ -119,6 +119,9 @@ This document is the canonical opcode inventory for `rwasm`.
 | 81 | `I32Add64` | — | — |
 | 82 | `BulkConst` | `NumLocals` | — |
 | 83 | `BulkDrop` | `NumLocals` | — |
+| 84 | `I32And64` | — | — |
+| 85 | `I32Or64` | — | — |
+| 86 | `I32Xor64` | — | — |
 
 ### fpu
 

--- a/src/isa/bitwise.rs
+++ b/src/isa/bitwise.rs
@@ -4,9 +4,9 @@ impl InstructionSet {
     pub const MSH_I64_CLZ: u32 = 3;
     pub const MSH_I64_CTZ: u32 = 3;
     pub const MSH_I64_POPCNT: u32 = 1;
-    pub const MSH_I64_AND: u32 = 1;
-    pub const MSH_I64_OR: u32 = 1;
-    pub const MSH_I64_XOR: u32 = 1;
+    pub const MSH_I64_AND: u32 = 0;
+    pub const MSH_I64_OR: u32 = 0;
+    pub const MSH_I64_XOR: u32 = 0;
     pub const MSH_I64_SHL: u32 = 9;
     pub const MSH_I64_SHR_S: u32 = 21;
     pub const MSH_I64_SHR_U: u32 = 21;
@@ -54,34 +54,19 @@ impl InstructionSet {
         self.op_i32_const(0);
     }
 
-    /// Max stack height: 1
+    /// Max stack height: 0
     pub fn op_i64_and(&mut self) {
-        self.op_local_get(3);
-        self.op_i32_and();
-        self.op_local_set(2);
-        self.op_local_get(3);
-        self.op_i32_and();
-        self.op_local_set(2);
+        self.op_i32_and64();
     }
 
-    /// Max stack height: 1
+    /// Max stack height: 0
     pub fn op_i64_or(&mut self) {
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
-        self.op_local_get(3);
-        self.op_i32_or();
-        self.op_local_set(2);
+        self.op_i32_or64();
     }
 
-    /// Max stack height: 1
+    /// Max stack height: 0
     pub fn op_i64_xor(&mut self) {
-        self.op_local_get(3);
-        self.op_i32_xor();
-        self.op_local_set(2);
-        self.op_local_get(3);
-        self.op_i32_xor();
-        self.op_local_set(2);
+        self.op_i32_xor64();
     }
 
     /// Max stack height: 9

--- a/src/isa/mod.rs
+++ b/src/isa/mod.rs
@@ -256,6 +256,9 @@ impl InstructionSet {
     impl_basic_opcode!(I32Extend16S);
     impl_basic_opcode!(I32Mul64);
     impl_basic_opcode!(I32Add64);
+    impl_basic_opcode!(I32And64);
+    impl_basic_opcode!(I32Or64);
+    impl_basic_opcode!(I32Xor64);
 
     // bulk opcodes
     impl_basic_opcode!(BulkConst(NumLocals));

--- a/src/types/opcode.rs
+++ b/src/types/opcode.rs
@@ -183,6 +183,9 @@ define_opcode_enum! {
     I32Add64 => 81u32,
     BulkConst(locals: NumLocals) => 82u32,
     BulkDrop(locals: NumLocals) => 83u32,
+    I32And64 => 84u32,
+    I32Or64 => 85u32,
+    I32Xor64 => 86u32,
 
     // fpu
     @fpu F32Load(offset: AddressOffset) => 0u32,
@@ -625,6 +628,9 @@ mod tests {
             Opcode::I32Add64,
             Opcode::BulkConst(3),
             Opcode::BulkDrop(3),
+            Opcode::I32And64,
+            Opcode::I32Or64,
+            Opcode::I32Xor64,
         ];
         for (expected, opcode) in opcodes.iter().enumerate() {
             assert_eq!(opcode.code(), expected as u32, "{opcode:#}");

--- a/src/vm/executor.rs
+++ b/src/vm/executor.rs
@@ -285,6 +285,9 @@ impl<'a, T> RwasmExecutor<'a, T> {
             I32Extend16S => self.visit_i32_extend16_s(),
             I32Mul64 => self.visit_i32_mul64(),
             I32Add64 => self.visit_i32_add64(),
+            I32And64 => self.visit_i32_and64(),
+            I32Or64 => self.visit_i32_or64(),
+            I32Xor64 => self.visit_i32_xor64(),
             BulkConst(imm) => self.visit_bulk_const(imm),
             BulkDrop(imm) => self.visit_bulk_drop(imm),
 

--- a/src/vm/executor/alu.rs
+++ b/src/vm/executor/alu.rs
@@ -78,6 +78,27 @@ impl<'a, T> RwasmExecutor<'a, T> {
         self.sp.push_i64(res);
         self.ip.add(1);
     }
+
+    pub(crate) fn visit_i32_and64(&mut self) {
+        let rhs = self.sp.pop_i64();
+        let lhs = self.sp.pop_i64();
+        self.sp.push_i64(lhs & rhs);
+        self.ip.add(1);
+    }
+
+    pub(crate) fn visit_i32_or64(&mut self) {
+        let rhs = self.sp.pop_i64();
+        let lhs = self.sp.pop_i64();
+        self.sp.push_i64(lhs | rhs);
+        self.ip.add(1);
+    }
+
+    pub(crate) fn visit_i32_xor64(&mut self) {
+        let rhs = self.sp.pop_i64();
+        let lhs = self.sp.pop_i64();
+        self.sp.push_i64(lhs ^ rhs);
+        self.ip.add(1);
+    }
 }
 
 macro_rules! impl_visit_fallible_binary {

--- a/tests/snippets.rs
+++ b/tests/snippets.rs
@@ -80,7 +80,8 @@ fn run_vm_instr(mut is: InstructionSet, inputs: Vec<u32>) -> Result<(Vec<u32>, u
         .iter()
         .map(|v| v.as_u32())
         .collect::<Vec<_>>();
-    let msh = value_stack.max_stack_height() - inputs_len;
+    // an in-place body can keep the stack at or below the input height for its whole run
+    let msh = value_stack.max_stack_height().saturating_sub(inputs_len);
     Ok((output, msh as u32))
 }
 


### PR DESCRIPTION
## What

Resolves [FLU-1181](https://linear.app/fluentlabs-xyz/issue/FLU-1181) (part of [FLU-1175](https://linear.app/fluentlabs-xyz/issue/FLU-1175)).

`i64.and/or/xor` previously expanded inline to 6 instructions each (`local_get`/`i32.op`/`local_set` × 2) and were the single largest inline contributor on i64-heavy code. Each now emits a single fused opcode.

## How

- New no-arg opcodes `I32And64` (84), `I32Or64` (85), `I32Xor64` (86) in `src/types/opcode.rs`, appended after `BulkDrop` so all existing opcode codes are unchanged (encoding is additive-only).
- Executor semantics in `src/vm/executor/alu.rs`: pop 4 limbs (two i64 operands), push 2 limbs — same multi-limb precedent as `I32Add64`/`I32Mul64`.
- `op_i64_and/or/xor` in `src/isa/bitwise.rs` become single-opcode emitters; `MSH_I64_AND/OR/XOR` drop to 0 (the fused op never grows the stack).
- Wired through executor dispatch, `impl_basic_opcode!`, opcode-order unit test, and `docs/opcodes.md`.
- Fuel: unchanged — translation-time `FuelCosts::BASE` per wasm op still applies via `translate_binary`.

Bitwise ops are fully limb-local (byte-local, in fact): no carry or range interaction between limbs, so in an SP1-style byte-lookup bitwise chip a 64-bit op is 8 byte lookups per row instead of 4 — same provability class as the existing fused opcodes.

The test harness msh computation switched to `saturating_sub` because an in-place body can keep the stack at or below the input height for its whole run (same fix as #185).

## Measured impact

Default fluentbase config, `tests/assets`, devel (8603d18e) vs this branch:

| asset | instrs before | instrs after | encoded before | encoded after |
|---|---|---|---|---|
| nitro-verifier-stack-ub | 330,841 | 290,801 (**−12.1%**) | 2,933,665 B | 2,645,377 B (**−288 KB, −9.8%**) |
| secp256k1-stack-ub | 26,763 | 26,538 | 2,356,729 B | 2,355,109 B |
| panic-stack-ub | 3,034 | 3,014 | 64,191 B | 64,047 B |

Also 6 → 1 *executed* instructions per use (fewer proving cycles), unlike the snippet-outlining alternative.

## Verification

- `cargo test` — full suite passes (incl. `tests/snippets.rs` coverage table and the `tests/wasmtime.rs` differential harness)
- `e2e` wasm spec testsuite: 92/92 pass
- Ignored release tests `test_nitro_verifier_rwasm` + `test_nitro_verifier_strategy` pass (full nitro attestation verification executes correctly on the fused opcodes)
- `cargo clippy --all-targets --all-features` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added 32-bit bitwise AND, OR, and XOR operations for 64-bit values.
  - Added opcode support and execution handling for the new operations.

- **Bug Fixes**
  - Improved stack-height handling for in-place instruction execution, preventing calculation underflow.

- **Documentation**
  - Documented the three new bitwise opcodes in the opcode catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
