### PR TITLE
feat: add I64Const32S/I64Const32U opcodes to emit i64.const as one instruction (FLU-1182)

### DIFF
--- a/docs/opcodes.md
+++ b/docs/opcodes.md
@@ -123,6 +123,8 @@ This document is the canonical opcode inventory for `rwasm`.
 | 85 | `I32Or64` | — | — |
 | 86 | `I32Xor64` | — | — |
 | 87 | `I32Sub64` | — | — |
+| 88 | `I64Const32S` | `UntypedValue` | — |
+| 89 | `I64Const32U` | `UntypedValue` | — |
 
 ### fpu
 

--- a/src/isa/memory.rs
+++ b/src/isa/memory.rs
@@ -1,5 +1,6 @@
 use crate::{
-    AddressOffset, DataSegmentIdx, I64ValueSplit, InstructionSet, TrapCode, N_BYTES_PER_MEMORY_PAGE,
+    AddressOffset, DataSegmentIdx, I64ValueSplit, InstructionSet, Opcode, TrapCode, UntypedValue,
+    N_BYTES_PER_MEMORY_PAGE,
 };
 use rwasm_fuel_policy::{MEMORY_BYTES_PER_FUEL, MEMORY_BYTES_PER_FUEL_LOG2};
 
@@ -128,8 +129,17 @@ impl InstructionSet {
     /// Max stack height: 2
     pub fn op_i64_const(&mut self, value: i64) {
         let (lo, hi) = value.split_into_i32_tuple();
-        self.op_i32_const(lo); // [lo]
-        self.op_i32_const(hi); // [hi, lo]
+        let lo_imm = UntypedValue::from_bits(lo as u32);
+        // constants whose high limb is derivable from the low one fit a single 8-byte opcode;
+        // only full-width 64-bit constants keep the two-instruction lowering
+        if hi == lo >> 31 {
+            self.push(Opcode::I64Const32S(lo_imm));
+        } else if hi == 0 {
+            self.push(Opcode::I64Const32U(lo_imm));
+        } else {
+            self.op_i32_const(lo); // [lo]
+            self.op_i32_const(hi); // [hi, lo]
+        }
     }
 
     /// Max stack height: 2

--- a/src/types/opcode.rs
+++ b/src/types/opcode.rs
@@ -554,6 +554,18 @@ mod tests {
     }
 
     #[test]
+    fn test_i64_const32_display() {
+        assert_eq!(
+            format!("{}", Opcode::I64Const32S(5u32.into())),
+            "I64Const32S(5)"
+        );
+        assert_eq!(
+            format!("{}", Opcode::I64Const32U(5u32.into())),
+            "I64Const32U(5)"
+        );
+    }
+
+    #[test]
     fn test_i64_const32_opcode_encoding() {
         for (opcode, code) in [
             (Opcode::I64Const32S(0xAABB_CCDDu32.into()), 88u32),

--- a/src/types/opcode.rs
+++ b/src/types/opcode.rs
@@ -424,7 +424,10 @@ impl Opcode {
     }
 
     pub fn is_nullary(&self) -> bool {
-        matches!(self, Opcode::Br(_) | Opcode::I32Const(_))
+        matches!(
+            self,
+            Opcode::Br(_) | Opcode::I32Const(_) | Opcode::I64Const32S(_) | Opcode::I64Const32U(_)
+        )
     }
 
     pub fn is_call_instruction(self) -> bool {
@@ -493,6 +496,8 @@ impl Opcode {
             }
             Opcode::TableInit(ele_seg_id) => *ele_seg_id,
             Opcode::ElemDrop(ele_seg_id) => *ele_seg_id,
+            Opcode::I64Const32S(value) => value.to_bits(),
+            Opcode::I64Const32U(value) => value.to_bits(),
             _ => 0,
         }
     }
@@ -733,6 +738,14 @@ mod tests {
             (Opcode::TableCopy(3, 7), (3u32 << 16) | 7),
             (Opcode::TableInit(38), 38),
             (Opcode::ElemDrop(39), 39),
+            (
+                Opcode::I64Const32S(UntypedValue::from_bits(0xDEAD_BEEF)),
+                0xDEAD_BEEF,
+            ),
+            (
+                Opcode::I64Const32U(UntypedValue::from_bits(0xDEAD_BEEF)),
+                0xDEAD_BEEF,
+            ),
             // Opcodes without an immediate report 0.
             (Opcode::I32Add, 0),
             (Opcode::Return, 0),
@@ -751,6 +764,8 @@ mod tests {
 
         assert!(Opcode::Br(1i32.into()).is_nullary());
         assert!(Opcode::I32Const(UntypedValue::from(0i32)).is_nullary());
+        assert!(Opcode::I64Const32S(UntypedValue::from(0i32)).is_nullary());
+        assert!(Opcode::I64Const32U(UntypedValue::from(0i32)).is_nullary());
         assert!(!Opcode::I32Add.is_nullary());
 
         assert!(Opcode::CallInternal(1).is_call_instruction());

--- a/src/types/opcode.rs
+++ b/src/types/opcode.rs
@@ -187,6 +187,13 @@ define_opcode_enum! {
     I32Or64 => 85u32,
     I32Xor64 => 86u32,
     I32Sub64 => 87u32,
+    // push a 64-bit constant whose value fits the single 32-bit immediate: the immediate is
+    // pushed as the low limb, then the derived high limb (top of stack = hi), matching the
+    // layout two consecutive `I32Const` pushes produce; `S` sign-extends the immediate into
+    // the high limb, `U` zero-extends it. Constants needing all 64 bits keep the two-`I32Const`
+    // lowering, so `Opcode` stays 8 bytes in memory
+    I64Const32S(value: UntypedValue) => 88u32,
+    I64Const32U(value: UntypedValue) => 89u32,
 
     // fpu
     @fpu F32Load(offset: AddressOffset) => 0u32,
@@ -270,6 +277,8 @@ impl core::fmt::Display for Opcode {
         } else {
             match self {
                 Opcode::I32Const(value) => write!(f, "I32Const({})", value),
+                Opcode::I64Const32S(value) => write!(f, "I64Const32S({})", value),
+                Opcode::I64Const32U(value) => write!(f, "I64Const32U({})", value),
                 Opcode::ConsumeFuel(value) => write!(f, "ConsumeFuel({})", value),
                 Opcode::Br(value) => write!(f, "Br({})", value.to_i32()),
                 Opcode::BrIfEqz(value) => write!(f, "BrIfEqz({})", value.to_i32()),
@@ -539,7 +548,27 @@ mod tests {
 
     #[test]
     fn test_opcode_size() {
+        // every opcode must keep fitting a single 64-bit register: widening any variant beyond
+        // one 32-bit immediate grows every in-memory instruction slot and slows dispatch
         assert_eq!(size_of::<Opcode>(), 8);
+    }
+
+    #[test]
+    fn test_i64_const32_opcode_encoding() {
+        for (opcode, code) in [
+            (Opcode::I64Const32S(0xAABB_CCDDu32.into()), 88u32),
+            (Opcode::I64Const32U(0xAABB_CCDDu32.into()), 89u32),
+        ] {
+            let data = bincode::encode_to_vec(opcode, bincode::config::legacy()).unwrap();
+            assert_eq!(data.len(), 8);
+            assert_eq!(&data[..4], &code.to_le_bytes());
+            assert_eq!(&data[4..8], &0xAABB_CCDDu32.to_le_bytes());
+
+            let (decoded, decoded_len): (Opcode, usize) =
+                bincode::decode_from_slice(&data, bincode::config::legacy()).unwrap();
+            assert_eq!(decoded, opcode);
+            assert_eq!(decoded_len, data.len());
+        }
     }
 
     #[test]
@@ -633,6 +662,8 @@ mod tests {
             Opcode::I32Or64,
             Opcode::I32Xor64,
             Opcode::I32Sub64,
+            Opcode::I64Const32S(42.into()),
+            Opcode::I64Const32U(42.into()),
         ];
         for (expected, opcode) in opcodes.iter().enumerate() {
             assert_eq!(opcode.code(), expected as u32, "{opcode:#}");

--- a/src/vm/executor.rs
+++ b/src/vm/executor.rs
@@ -250,6 +250,8 @@ impl<'a, T> RwasmExecutor<'a, T> {
             GlobalSet(imm) => self.visit_global_set(imm),
             RefFunc(imm) => self.visit_ref_func(imm),
             I32Const(imm) => self.visit_i32_const(imm),
+            I64Const32S(imm) => self.visit_i64_const32_s(imm),
+            I64Const32U(imm) => self.visit_i64_const32_u(imm),
 
             I32Eqz => self.visit_i32_eqz(),
             I32Eq => self.visit_i32_eq(),

--- a/src/vm/executor/stack.rs
+++ b/src/vm/executor/stack.rs
@@ -54,6 +54,21 @@ impl<'a, T> RwasmExecutor<'a, T> {
     }
 
     #[inline(always)]
+    pub(crate) fn visit_i64_const32_s(&mut self, lo: UntypedValue) {
+        let hi = ((lo.to_bits() as i32) >> 31) as u32;
+        self.sp.push(lo);
+        self.sp.push(UntypedValue::from_bits(hi));
+        self.ip.add(1);
+    }
+
+    #[inline(always)]
+    pub(crate) fn visit_i64_const32_u(&mut self, lo: UntypedValue) {
+        self.sp.push(lo);
+        self.sp.push(UntypedValue::from_bits(0));
+        self.ip.add(1);
+    }
+
+    #[inline(always)]
     pub(crate) fn visit_bulk_const(&mut self, imm: NumLocals) {
         // TODO(dmitry123): We can optimize it, but need to support bulk stack reset
         for _ in 0..imm {


### PR DESCRIPTION
## What

`op_i64_const` previously lowered every `i64.const` into two `I32Const` instructions (2 instrs / 16 encoded bytes). This adds two fused opcodes that carry a single 32-bit immediate and push both limbs in one step, producing the exact same stack layout (`lo` pushed first, then `hi`, top = hi):

- `I64Const32S(value)` (code 88) — high limb = sign-extension of the immediate
- `I64Const32U(value)` (code 89) — high limb = 0

Constants that genuinely need all 64 bits keep the two-`I32Const` lowering. Measured on the nitro asset, 59.8% of `i64.const` values are sign-extendable, 36.6% have a zero high limb, and only 3.6% (579 of 16,178) need the fallback — so 96.4% of uses become 1 instr / 8 encoded bytes.

**`Opcode` stays 8 bytes in memory** (single-register loads, no cache-footprint regression for the rest of the bytecode); `test_opcode_size` pins this. Circuit-wise both variants are limb-local: the high limb is a trivial function of the immediate (arithmetic shift or zero), the same provability class as merged `I32Const` rows, matching the `I32Add64`/`I32Mul64`/`I32And64`/`I32Sub64` precedent. The encoding stays fully 32-bit-aligned (u32 code + u32 immediate).

## Changes

- `src/types/opcode.rs`: new `I64Const32S`/`I64Const32U` variants (codes 88/89, after `I32Sub64` from #187), `Display` arms, round-trip encode/decode test, updated code-value test, `test_opcode_size` pins `size_of::<Opcode>() == 8`
- `src/isa/memory.rs`: `op_i64_const` picks S / U / two-`I32Const` fallback; `MSH_I64_CONST` stays 2; `f64.const` benefits via the same path
- `src/vm/executor.rs` + `src/vm/executor/stack.rs`: dispatch + `visit_i64_const32_s`/`_u` (2 pushes, 1 ip step)
- `docs/opcodes.md`: catalog rows for codes 88–89

## Measured impact

Same config on `tests/assets`, current devel (3073baf6, incl. #185–#189) vs this branch:

| asset | instrs | encoded bytes |
|---|---|---|
| nitro-verifier | 289,921 → 274,321 (**−15,600, −5.4%**) | 2,639,349 → 2,514,549 (**−124,800, −4.7%**) |
| secp256k1 | 26,535 → 26,077 | 2,355,093 → 2,351,429 |
| panic | 3,014 → 3,004 | 64,047 → 63,967 |

Encoded saving is −8 bytes per fitting use (16 → 8), matching the FLU-1182 estimate of −16K instrs / −5% count on nitro.

## Verification

- Full `cargo test` suite passes on top of current devel (incl. `tests/snippets.rs` `test_i64_const`, whose edge-case constants exercise all three lowerings through the VM, and the wasmtime differential strategy tests in `tests/fuzz.rs`)
- `cargo test --release --test fluentbase -- --ignored` (real nitro attestation verification workload) passes
- New encode/decode round-trip test pins the wire format: `[code, imm]` little-endian, 8 bytes
- `cargo clippy --all-targets` clean

Linear: [FLU-1182](https://linear.app/fluentlabs-xyz/issue/FLU-1182)