### PR TITLE
fix(isa): trap on memory.init from an empty passive data segment (FLU-1213)

### DIFF
--- a/src/isa/memory.rs
+++ b/src/isa/memory.rs
@@ -259,7 +259,7 @@ impl InstructionSet {
         // note that this compare is signed and `n + s` wraps, so operands close to `i32::MAX`
         // slip past it — the data segment bounds check inside `memory.init` below is what
         // actually rejects them, this guard only turns the common case into an early trap
-        if let Some(length) = rewrite_length.filter(|v| *v > 0) {
+        if let Some(length) = rewrite_length {
             self.op_local_get(1); // n
             self.op_local_get(3); // s
             self.op_i32_add(); // n + s

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -1,6 +1,6 @@
 use rwasm::{
-    always_failing_syscall_handler, instruction_set, ExecutionEngine, ImportLinker, RwasmModule,
-    RwasmModuleBuilder, RwasmStore,
+    always_failing_syscall_handler, instruction_set, CompilationConfig, ExecutionEngine,
+    ImportLinker, RwasmModule, RwasmModuleBuilder, RwasmStore, TrapCode, Value,
 };
 
 fn execute_module(module: &RwasmModule) -> u64 {
@@ -47,4 +47,101 @@ fn test_memory_fuel_ddos_not_possible() {
     println!("{}", rwasm_module);
     let fuel_consumed = execute_module(&rwasm_module);
     assert_eq!(fuel_consumed, 3);
+}
+
+/// Compiles a WAT module exporting a `test` function with an `i32` result and runs it.
+fn execute_wat(wat_str: &str) -> Result<i32, TrapCode> {
+    let wasm_binary = wat::parse_str(wat_str).expect("valid WAT");
+    let config = CompilationConfig::default()
+        .with_entrypoint_name("test".into())
+        .with_allow_malformed_entrypoint_func_type(true);
+    let (rwasm_module, _) = RwasmModule::compile(config, &wasm_binary).unwrap();
+    println!("{}", rwasm_module);
+    let mut store = RwasmStore::<()>::default();
+    let instance = ImportLinker::default()
+        .instantiate(&mut store, ExecutionEngine::new(), rwasm_module)
+        .unwrap();
+    let mut result = [Value::I32(0); 1];
+    instance.execute(&mut store, &[], &mut result)?;
+    Ok(result[0].i32().unwrap())
+}
+
+/// `memory.init x` must trap when `s + n > len(data[x])`, so any `n > 0` on an empty
+/// passive segment always traps. All data segments are merged into one flat data section,
+/// so without the injected per-segment guard an empty segment reads its neighbor's bytes.
+#[test]
+fn test_memory_init_empty_first_segment_traps() {
+    assert_eq!(
+        execute_wat(
+            r#"
+(module
+  (memory 1)
+  (data "")          ;; segment 0, empty
+  (data "ABCD")
+  (func (export "test") (result i32)
+    (memory.init 0 (i32.const 0) (i32.const 0) (i32.const 4))
+    (i32.load (i32.const 0))))
+"#
+        ),
+        Err(TrapCode::MemoryOutOfBounds),
+    );
+}
+
+/// Same as above, but the empty segment is not first: the offset rewrite applies, so a
+/// missing length guard leaks the *following* segment's bytes instead of the first one's.
+#[test]
+fn test_memory_init_empty_middle_segment_traps() {
+    assert_eq!(
+        execute_wat(
+            r#"
+(module
+  (memory 1)
+  (data "WXYZ")
+  (data "")          ;; segment 1, empty
+  (data "1234")
+  (func (export "test") (result i32)
+    (memory.init 1 (i32.const 0) (i32.const 0) (i32.const 4))
+    (i32.load (i32.const 0))))
+"#
+        ),
+        Err(TrapCode::MemoryOutOfBounds),
+    );
+}
+
+/// A zero-length `memory.init` on an empty segment is well-defined and must not trap.
+#[test]
+fn test_memory_init_empty_segment_zero_length_is_ok() {
+    assert_eq!(
+        execute_wat(
+            r#"
+(module
+  (memory 1)
+  (data "")          ;; segment 0, empty
+  (data "ABCD")
+  (func (export "test") (result i32)
+    (memory.init 0 (i32.const 0) (i32.const 0) (i32.const 0))
+    (i32.load (i32.const 0))))
+"#
+        ),
+        Ok(0),
+    );
+}
+
+/// Control: a non-empty segment still initializes memory from its own bytes.
+#[test]
+fn test_memory_init_non_empty_segment_still_copies() {
+    assert_eq!(
+        execute_wat(
+            r#"
+(module
+  (memory 1)
+  (data "WXYZ")
+  (data "1234")
+  (func (export "test") (result i32)
+    (memory.init 1 (i32.const 0) (i32.const 0) (i32.const 4))
+    (i32.load (i32.const 0))))
+"#
+        ),
+        Ok(0x34333231),
+    );
 }


### PR DESCRIPTION
## Problem

`op_memory_init_checked` ([src/isa/memory.rs:262](https://github.com/fluentlabs-xyz/rwasm/blob/devel/src/isa/memory.rs#L262)) filtered the injected source-range guard with `> 0`:

```rust
if let Some(length) = rewrite_length.filter(|v| *v > 0) {
```

so an **empty** data segment emitted no guard at all.

rwasm merges every data segment into one flat `data_section`, and the runtime `visit_memory_init` slices that *global* buffer. The per-segment bound exists **only** in this compile-time prologue. With the guard suppressed, `memory.init` on an empty segment read whatever segment sat next in the merged buffer.

Per spec, `memory.init x` must trap when `s + n > len(data[x])`, so any `n > 0` on an empty segment always traps.

### Impact

- Spec violation
- Cross-segment data disclosure
- Determinism divergence against the Wasmtime differential oracle

```wat
(module
  (memory 1)
  (data "")          ;; segment 0, empty
  (data "ABCD")
  (func (export "test") (result i32)
    (memory.init 0 (i32.const 0) (i32.const 0) (i32.const 4))
    (i32.load (i32.const 0))))
```

Expected a trap; returned `Ok(0x44434241)` — `memory[0..4] == "ABCD"`. With the empty segment in second position it leaks the *following* segment's bytes, since the offset rewrite still applies but the length check does not.

## Fix

Drop the filter. The guard then emits `n + s > 0`, exactly the spec condition, and stays a no-op for `n == s == 0`.

`MSH_MEMORY_INIT_CHECKED = 2` is unaffected — the guard still peaks at 2 slots.

## Why the spec suite missed it

`e2e/testsuite/memory_init.wast` contains zero empty data segments. `bulk.wast` has 65 of them but only ever pairs them with `data.drop`, never `memory.init`. A coverage gap upstream as well.

The sibling `op_table_init_checked` emits the identical check unconditionally, which is why `table.init` on an empty elem segment already trapped correctly.

## Tests

Four regression tests in `tests/memory.rs`:

- `test_memory_init_empty_first_segment_traps` — empty segment in first position
- `test_memory_init_empty_middle_segment_traps` — empty segment in non-first position (leaked the *following* segment)
- `test_memory_init_empty_segment_zero_length_is_ok` — `n == 0` stays well-defined, no trap
- `test_memory_init_non_empty_segment_still_copies` — control, normal path unchanged

Both trap tests were confirmed to fail on the unfixed code (returning `0x44434241` / `"1234"`) and pass after.

Full suite green, including the 92 e2e spec tests. `clippy --all-targets` clean; the two touched files are rustfmt-clean.

Closes FLU-1213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected `memory.init` bounds checking when the requested rewrite length is zero.
  - Empty segments now correctly trigger an out-of-bounds trap when their position exceeds available memory.
  - Zero-length initialization on an empty segment remains valid and completes successfully.
  - Non-empty segments continue to copy their data correctly.

- **Tests**
  - Added coverage for empty, zero-length, middle-segment, and non-empty memory initialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->