### PR TITLE
fix(compiler): trap when initial memory exceeds the store page limit

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -9,18 +9,17 @@
 //!
 //! Reference: `https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/fuzz/fuzz_targets/differential.rs`
 
-use anyhow::Context;
 use libfuzzer_sys::{
     arbitrary::{self, Result, Unstructured},
     fuzz_target,
 };
 use rwasm::{
-    CompilationConfig, ExecutionEngine, ExternRef, FuncRef, RwasmModule, RwasmStore, StoreTr,
-    TrapCode, Value,
+    CompilationConfig, ExecutionEngine, ExternRef, FuncRef, ImportLinker, RwasmModule, RwasmStore,
+    StoreTr, TrapCode, Value,
 };
 use std::sync::{
     atomic::{AtomicUsize, Ordering::SeqCst},
-    Once,
+    Arc, Once,
 };
 use wasm_smith as smith;
 use wasmparser::{Parser, Payload, ValType as ParserValType};
@@ -36,6 +35,20 @@ const MAX_EXPORTS: usize = 8;
 ///
 /// We compare *remaining* fuel after execution, which implies consumed fuel must match too.
 const FUEL_LIMIT: u64 = 50_000_000;
+
+/// Page cap applied to *both* the compiler config and the store; see `run_rwasm_one`.
+///
+/// These are two independent knobs in rwasm and the harness must keep them equal: the compiler
+/// bounds a module's initial memory by its own limit, while the `memory.grow` it emits into the
+/// entrypoint prologue is bounded by the store's. If the store's is the smaller one, every module
+/// declaring more pages than it fails instantiation in rwasm while wasmtime runs it fine.
+const MAX_MEMORY_PAGES: u32 = rwasm::N_DEFAULT_MAX_MEMORY_PAGES;
+
+/// Upper bound on generated linear memory, kept well under [`MAX_MEMORY_PAGES`] so that generated
+/// modules land inside the comparable subset rather than being skipped as `MaxReadonlyDataReached`.
+/// It also bounds the harness's own RSS: a fresh store is built per invocation and each one
+/// materializes its memory for real, so raising this trades directly against libFuzzer's rss limit.
+const MAX_GENERATED_MEMORY_PAGES: u64 = 512;
 
 /// How many table elements we compare (nullness only) for each exported table.
 ///
@@ -150,10 +163,16 @@ fn execute_one(data: &[u8]) -> Result<()> {
     gen_cfg.gc_enabled = false;
     gen_cfg.exceptions_enabled = false;
 
+    // this wasmtime-rwasm build has pulley's float opcodes compiled out, so the oracle traps with
+    // "pulley opcode disabled at compile time" on *every* float operation while rwasm (built with
+    // `fpu`) executes it fine. generating floats would therefore report a mismatch per float module.
+    gen_cfg.allow_floats = false;
+
     // Keep generated modules inside the currently supported differential subset.
     gen_cfg.max_imports = 0;
     gen_cfg.max_memories = 1;
     gen_cfg.min_memories = 1;
+    gen_cfg.max_memory32_bytes = MAX_GENERATED_MEMORY_PAGES * rwasm::N_BYTES_PER_MEMORY_PAGE as u64;
     gen_cfg.min_tables = 1;
     // Keep table model inside currently stable rwasm differential subset.
     gen_cfg.max_tables = 1;
@@ -394,7 +413,7 @@ fn run_rwasm_one(
         .with_consume_fuel(true)
         .with_consume_fuel_for_params_and_locals(false)
         .with_allow_func_ref_function_types(false)
-        .with_max_allowed_memory_pages(4096);
+        .with_max_allowed_memory_pages(MAX_MEMORY_PAGES);
 
     let (module, _) = match RwasmModule::compile(config, wasm) {
         Ok(x) => x,
@@ -406,7 +425,17 @@ fn run_rwasm_one(
     };
 
     let engine = ExecutionEngine::default();
-    let mut store = RwasmStore::<()>::default();
+    // the store's page cap is independent of the compiler's, and defaults to
+    // `N_DEFAULT_MAX_MEMORY_PAGES` (1024). it must match `with_max_allowed_memory_pages` above,
+    // or every module declaring more than 1024 initial pages fails instantiation in rwasm while
+    // wasmtime happily runs it.
+    let mut store = RwasmStore::<()>::new(
+        Arc::new(ImportLinker::default()),
+        (),
+        rwasm::always_failing_syscall_handler,
+        None,
+        Some(MAX_MEMORY_PAGES),
+    );
 
     // Materialize module runtime state (tables/memory/data/elements/start path) before invoking
     // exported function body, mirroring Wasmtime instantiation semantics.
@@ -707,7 +736,7 @@ struct RawWasmtimeInstance {
 impl RawWasmtimeInstance {
     fn new(mut store: Store<()>, module: Module) -> anyhow::Result<Self> {
         let instance = Instance::new(&mut store, &module, &[])
-            .context("unable to instantiate module in wasmtime")?;
+            .map_err(|e| anyhow::anyhow!("unable to instantiate module in wasmtime: {e}"))?;
         // Keep differential fuel accounting call-scoped (exclude instantiation/start side costs).
         store
             .set_fuel(FUEL_LIMIT)

--- a/fuzz/src/bin/repro_artifact.rs
+++ b/fuzz/src/bin/repro_artifact.rs
@@ -42,16 +42,23 @@ fn main() -> anyhow::Result<()> {
     gen_cfg.shared_everything_threads_enabled = false;
     gen_cfg.gc_enabled = false;
     gen_cfg.exceptions_enabled = false;
+    // see `fuzz_targets/differential.rs`: the wasmtime oracle cannot execute float opcodes.
+    gen_cfg.allow_floats = false;
 
     // Keep generated modules inside the currently supported differential subset.
     gen_cfg.max_imports = 0;
     gen_cfg.max_memories = 1;
     gen_cfg.min_memories = 1;
+    gen_cfg.max_memory32_bytes = 512 * rwasm::N_BYTES_PER_MEMORY_PAGE as u64;
     gen_cfg.min_tables = 1;
     // Keep table model inside currently stable rwasm differential subset.
     gen_cfg.max_tables = 1;
     // Keep wasm-smith table limits inside rwasm runtime hard cap.
     gen_cfg.max_table_elements = rwasm::N_MAX_TABLE_SIZE as u64;
+    // keep in sync with `fuzz_targets/differential.rs`, otherwise the same artifact bytes
+    // reproduce a *different* module than the one the fuzz target generated.
+    gen_cfg.min_data_segments = 4;
+    gen_cfg.min_element_segments = 4;
     gen_cfg.export_everything = true;
 
     let module = smith::Module::new(gen_cfg, &mut u)

--- a/src/compiler/segment_builder.rs
+++ b/src/compiler/segment_builder.rs
@@ -1,7 +1,7 @@
 use crate::{
     instruction_set, CompilationError, DataSegmentIdx, ElementSegmentIdx, GlobalIdx,
-    GlobalVariable, I64ValueSplit, InstructionSet, TableIdx, DEFAULT_MEMORY_INDEX, NULL_FUNC_IDX,
-    N_BYTES_PER_MEMORY_PAGE,
+    GlobalVariable, I64ValueSplit, InstructionSet, TableIdx, TrapCode, DEFAULT_MEMORY_INDEX,
+    NULL_FUNC_IDX, N_BYTES_PER_MEMORY_PAGE,
 };
 use alloc::{vec, vec::Vec};
 use hashbrown::HashMap;
@@ -88,9 +88,16 @@ impl SegmentBuilder {
             self.entrypoint_bytecode.op_i32_const(initial_pages);
             self.entrypoint_bytecode
                 .op_memory_grow_checked(None, consume_fuel_for_bulk_ops);
-            // there is no need to verify for a potential trap because it can't overflow,
-            // we have this check upper during the compilation time
-            self.entrypoint_bytecode.op_drop();
+            // the check above bounds `initial_pages` by the *compiler's* limit, but the grow we
+            // just emitted is bounded at runtime by the *store's* `max_allowed_memory_pages`,
+            // which is an independent knob and can be smaller. so the result must be verified:
+            // `memory.grow` reports failure as `u32::MAX`, and dropping it unchecked would leave
+            // the module running on a 0-page memory with instantiation reported as successful
+            // (`memory.size` reads 0, every access traps at some arbitrary later point).
+            self.entrypoint_bytecode.op_i32_const(u32::MAX);
+            self.entrypoint_bytecode.op_i32_eq();
+            self.entrypoint_bytecode.op_br_if_eqz(2);
+            self.entrypoint_bytecode.op_trap(TrapCode::MemoryOutOfBounds);
         }
         // increase the total number of pages allocated
         self.total_allocated_pages = next_pages;

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -145,3 +145,79 @@ fn test_memory_init_non_empty_segment_still_copies() {
         Ok(0x34333231),
     );
 }
+
+/// The compile-time page check in `SegmentBuilder::add_memory_pages` bounds the module's initial
+/// memory by `CompilationConfig::max_allowed_memory_pages`, but the `memory.grow` it emits into the
+/// entrypoint prologue is bounded at runtime by `RwasmStore::max_allowed_memory_pages` — an
+/// independent knob. When the store's limit is the smaller of the two, that grow fails, and the
+/// failure used to be dropped unchecked: instantiation reported success and the module then ran on
+/// a 0-page memory, so `memory.size` silently read 0 instead of the declared page count.
+///
+/// Found by the differential fuzzer (`fuzz/artifacts/differential/crash-d87768b3f90ac…`), where
+/// wasmtime instantiated the same module and rwasm reported `MemoryOutOfBounds` from an unrelated
+/// later access.
+mod initial_memory_exceeding_store_limit {
+    use rwasm::{
+        always_failing_syscall_handler, CompilationConfig, ExecutionEngine, ImportLinker,
+        RwasmModule, RwasmStore, TrapCode, Value, N_DEFAULT_MAX_MEMORY_PAGES,
+    };
+    use std::sync::Arc;
+
+    /// One page more than the store's default cap, so the prologue grow cannot succeed on a
+    /// default store. The compiler is configured to allow exactly this many pages, so the module
+    /// compiles and only the store's independent limit stands in the way.
+    const PAGES: u32 = N_DEFAULT_MAX_MEMORY_PAGES + 1;
+
+    fn compile() -> RwasmModule {
+        let wat = format!(
+            r#"(module (memory {PAGES}) (func (export "size") (result i32) memory.size))"#
+        );
+        let wasm = wat::parse_str(wat).expect("valid WAT");
+        let config = CompilationConfig::default()
+            .with_entrypoint_name("size".into())
+            .with_allow_malformed_entrypoint_func_type(true)
+            .with_max_allowed_memory_pages(PAGES);
+        let (module, _) = RwasmModule::compile(config, &wasm).expect("module compiles");
+        module
+    }
+
+    fn store(max_allowed_memory_pages: Option<u32>) -> RwasmStore<()> {
+        RwasmStore::new(
+            Arc::new(ImportLinker::default()),
+            (),
+            always_failing_syscall_handler,
+            None,
+            max_allowed_memory_pages,
+        )
+    }
+
+    #[test]
+    fn entrypoint_traps_instead_of_leaving_memory_unallocated() {
+        let module = compile();
+        let engine = ExecutionEngine::new();
+        let mut store = store(None);
+
+        assert_eq!(
+            engine.entrypoint(&mut store, &module),
+            Err(TrapCode::MemoryOutOfBounds),
+            "instantiation must fail when the initial memory exceeds the store's page limit"
+        );
+    }
+
+    #[test]
+    fn memory_is_fully_materialized_when_the_store_allows_it() {
+        let module = compile();
+        let engine = ExecutionEngine::new();
+        let mut store = store(Some(PAGES));
+
+        engine
+            .entrypoint(&mut store, &module)
+            .expect("instantiation succeeds when the store's limit covers the initial memory");
+
+        let mut result = [Value::I32(0); 1];
+        engine
+            .execute(&mut store, &module, &[], &mut result)
+            .expect("memory.size does not trap");
+        assert_eq!(result[0].i32(), Some(PAGES as i32));
+    }
+}


### PR DESCRIPTION
## Summary

`SegmentBuilder::add_memory_pages` emitted `i32.const N; memory.grow; drop` into the entrypoint prologue and discarded the grow result, on the stated grounds that the compile-time check made failure impossible:

```rust
// there is no need to verify for a potential trap because it can't overflow,
// we have this check upper during the compilation time
self.entrypoint_bytecode.op_drop();
```

That check bounds `initial_pages` by `CompilationConfig::max_allowed_memory_pages`, but the emitted grow is bounded at runtime by `RwasmStore::max_allowed_memory_pages` — an independent knob defaulting to `N_DEFAULT_MAX_MEMORY_PAGES` (1024). When the store's limit is the smaller of the two, the grow fails and the `u32::MAX` sentinel was dropped unchecked.

The module then ran on a **0-page memory with instantiation reported as successful**:

```wat
(module (memory 1025) (func (export "size") (result i32) memory.size))
```

```
entrypoint = Ok(())
memory.size = 0        ;; declared 1025
```

A silently wrong answer, with the eventual `MemoryOutOfBounds` surfacing at whatever access happened to touch memory first rather than at instantiation.

The fix verifies the sentinel and traps `MemoryOutOfBounds`, matching how `op_table_init_checked` and `op_memory_init_checked` guard their own paths.

## How it was found

The differential fuzzer, on a module declaring 1438 pages that wasmtime instantiated and ran fine:

```
diff: export= wasmtime=Ok rwasm_trap=MemoryOutOfBounds args=[] result_tys=[]
```

## Tests

Two regression tests in `tests/memory.rs::initial_memory_exceeding_store_limit`, covering the trap and the successful path when the store's limit does cover the module. Confirmed genuine — with the fix stashed, `entrypoint_traps_instead_of_leaving_memory_unallocated` fails with `left: Ok(()) / right: Err(MemoryOutOfBounds)`.

`cargo test` fully green, `cargo clippy --all-targets` clean.

## Second commit: differential harness

The harness did not compile at all on `devel` — `anyhow::Context` no longer applies to `wasmtime_rwasm::Error`, which stopped implementing `std::error::Error` in wasmtime 45. Beyond that, four issues that each produced false-positive mismatches rather than real findings:

- **Store/compiler page caps diverged.** The harness compiled with 4096 while the store defaulted to 1024, so every module over 1024 initial pages failed instantiation in rwasm while wasmtime ran it. Both now derive from one `MAX_MEMORY_PAGES` constant. This is the same divergence the compiler fix addresses, seen from the caller's side.
- **Generated memory was unbounded.** Modules were routinely discarded as `MaxReadonlyDataReached`, and the memory that did materialize drove libFuzzer past its rss limit (a fresh store is built per invocation). Now bounded via `max_memory32_bytes`.
- **The oracle cannot execute floats.** This wasmtime-rwasm build has pulley's float opcodes compiled out, so it traps with `pulley opcode disabled at compile time` on every float operation while rwasm, built with `fpu`, executes it correctly. Verified on a two-instruction module under both signal configurations. Floats are outside the comparable subset, so they are no longer generated.
- **`repro_artifact` did not mirror the target's generator config**, so the same artifact bytes reproduced a *different* module than the one that crashed — an active source of misdiagnosis.

## Compatibility

This changes emitted bytecode, so compiled modules hash differently than before. `RWASM_VERSION_V1` covers the container format rather than codegen, so nothing to bump, but any persisted or cached compiled modules need regenerating.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when a module’s initial memory exceeds the runtime store limit.
  - Memory growth now reports a clear out-of-bounds trap instead of silently continuing.
  - Preserved detailed instantiation error messages for easier diagnosis.

- **Tests**
  - Added coverage for memory limits during module initialization and successful execution when limits are sufficient.
  - Improved fuzzing consistency and reproducibility by aligning generated module constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->