### PR TITLE
fix(compiler): make the initial-memory page limit inclusive (FLU-1214)

### DIFF
--- a/src/compiler/segment_builder.rs
+++ b/src/compiler/segment_builder.rs
@@ -75,9 +75,11 @@ impl SegmentBuilder {
         max_allowed_memory_pages: u32,
         consume_fuel_for_bulk_ops: bool,
     ) -> Result<(), CompilationError> {
-        // there is a hard limit of max possible memory used (~64 mB)
+        // there is a hard limit of max possible memory used (~64 mB); the limit is inclusive,
+        // matching what the runtime permits: `GlobalMemory::grow` and the guard injected by
+        // `op_memory_grow_checked` both reject only a page count strictly above the limit
         let next_pages = self.total_allocated_pages.saturating_add(initial_pages);
-        if next_pages >= max_allowed_memory_pages {
+        if next_pages > max_allowed_memory_pages {
             return Err(CompilationError::MaxReadonlyDataReached);
         }
         // it makes no sense to grow memory with 0 pages

--- a/tests/compiler.rs
+++ b/tests/compiler.rs
@@ -1,4 +1,7 @@
-use rwasm::{CompilationConfig, CompilationError, ConstructorParams, RwasmModule};
+use rwasm::{
+    always_failing_syscall_handler, CompilationConfig, CompilationError, ConstructorParams,
+    ExecutionEngine, ImportLinker, RwasmModule, RwasmStore, Value,
+};
 
 fn test_compilation(wat_str: &str) -> Result<(RwasmModule, ConstructorParams), CompilationError> {
     let wasm = wat::parse_str(wat_str).expect("valid WAT");
@@ -165,4 +168,52 @@ fn test_max_locals_single_func() {
         output_size,
         output_size as f64 / 1_000_000.0
     );
+}
+
+/// The compile-time initial-memory limit is inclusive, exactly like the runtime one enforced by
+/// `GlobalMemory::grow` and by the guard injected for `memory.grow`.
+#[test]
+fn test_initial_memory_at_max_allowed_pages_is_accepted() {
+    const MAX_PAGES: u32 = 4;
+
+    fn memory_size_module(initial_pages: u32) -> Vec<u8> {
+        wat::parse_str(format!(
+            r#"
+(module
+  (memory {initial_pages})
+  (func (export "t") (result i32) (memory.size))
+)
+"#
+        ))
+        .expect("valid WAT")
+    }
+    fn config() -> CompilationConfig {
+        CompilationConfig::default()
+            .with_max_allowed_memory_pages(MAX_PAGES)
+            .with_entrypoint_name("t".into())
+            .with_allow_malformed_entrypoint_func_type(true)
+    }
+
+    // exactly the limit is accepted, one page above it is not
+    let (rwasm_module, _) = RwasmModule::compile(config(), &memory_size_module(MAX_PAGES))
+        .expect("initial memory equal to the limit must compile");
+    assert!(matches!(
+        RwasmModule::compile(config(), &memory_size_module(MAX_PAGES + 1)),
+        Err(CompilationError::MaxReadonlyDataReached),
+    ));
+
+    // and the accepted module really gets its declared memory at runtime
+    let mut store = RwasmStore::new(
+        ImportLinker::default().into(),
+        (),
+        always_failing_syscall_handler,
+        None,
+        Some(MAX_PAGES),
+    );
+    let instance = ImportLinker::default()
+        .instantiate(&mut store, ExecutionEngine::new(), rwasm_module)
+        .unwrap();
+    let mut result = [Value::I32(0); 1];
+    instance.execute(&mut store, &[], &mut result).unwrap();
+    assert_eq!(result[0].i32().unwrap(), MAX_PAGES as i32);
 }


### PR DESCRIPTION
Closes [FLU-1214](https://linear.app/fluentlabs-xyz/issue/FLU-1214/medium-initial-memory-page-limit-is-off-by-one-against-the-runtime).

## Problem

`SegmentBuilder::add_memory_pages` enforced the configured memory cap with `>=`:

```rust
let next_pages = self.total_allocated_pages.saturating_add(initial_pages);
if next_pages >= max_allowed_memory_pages {
    return Err(CompilationError::MaxReadonlyDataReached);
}
```

Both runtime enforcement sites treat the same limit as inclusive:

* `GlobalMemory::grow` (`src/vm/memory.rs:51`) — `desired_pages > self.max_allowed_memory_pages`
* the guard injected by `op_memory_grow_checked` (`src/isa/memory.rs`) — `memory_size + d > max_pages`

So with the default cap of `N_DEFAULT_MAX_MEMORY_PAGES = 1024`, `(memory 1024)` was rejected at compile time, while the exact same page count was reachable at runtime through `memory.grow`. The declarative and dynamic paths disagreed by one page.

## Fix

Change the compile-time check to `>` so all three sites agree on an inclusive limit — inclusive is the reading the runtime already permits.

## Test

`test_initial_memory_at_max_allowed_pages_is_accepted` in `tests/compiler.rs`:

* initial memory exactly at the limit compiles
* one page above it still fails with `MaxReadonlyDataReached`
* the accepted module, executed with a store capped at the same limit, reports `memory.size == max_pages`

Verified the test fails on the unfixed code (`MaxReadonlyDataReached` on the first assertion) and passes with the fix.

`cargo test` (root, all suites) and `cargo test` in `e2e/` (92 spec tests) are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modules can now compile successfully when initial memory exactly matches the configured maximum page limit.
  * Memory allocations exceeding the configured limit continue to be rejected.
  * Runtime memory sizing now remains consistent with compile-time validation.

* **Tests**
  * Added coverage confirming acceptance at the maximum limit and rejection above it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->