### PR TITLE
fix(compiler): close out the low-severity rWasm audit findings (FLU-1212)

### DIFF
--- a/src/compiler/segment_builder.rs
+++ b/src/compiler/segment_builder.rs
@@ -120,11 +120,13 @@ impl SegmentBuilder {
 
     pub fn add_active_memory(&mut self, segment_idx: DataSegmentIdx, offset: u32, bytes: &[u8]) {
         // don't allow growing default memory if there are no enough pages allocated
+        // `None` means the page arithmetic overflowed `u32`, which is itself proof that the
+        // segment is out of range, so the caller below must treat it as an overflow
         let has_memory_overflow = || -> Option<bool> {
             let max_affected_page = offset
                 .checked_add(bytes.len() as u32)?
                 .checked_add(N_BYTES_PER_MEMORY_PAGE - 1)?
-                .checked_div(N_BYTES_PER_MEMORY_PAGE)?;
+                / N_BYTES_PER_MEMORY_PAGE;
             Some(max_affected_page > self.total_allocated_pages)
         };
         // expand default memory
@@ -134,7 +136,7 @@ impl SegmentBuilder {
         // default memory is just a passive section with force memory init
         self.entrypoint_bytecode.op_i32_const(offset);
         self.entrypoint_bytecode.op_i32_const(data_offset);
-        if has_memory_overflow().unwrap_or_default() {
+        if has_memory_overflow().unwrap_or(true) {
             self.entrypoint_bytecode.op_i32_const(u32::MAX);
         } else {
             self.entrypoint_bytecode.op_i32_const(data_length);

--- a/src/compiler/translator.rs
+++ b/src/compiler/translator.rs
@@ -1211,7 +1211,9 @@ impl<'a> VisitOperator<'a> for InstructionTranslator {
             builder.stack_height.pop1();
             builder.alloc.stack_types.pop().unwrap();
             let mut drop_keep = builder.drop_keep_return_call(func_type)?;
-            // TODO(dmitry123): "why? is there a bug in [drop_keep_return_call]?"
+            // `keep` covers the callee params; re-add the func index that the `pop1()` above
+            // removed from the emulated height but that `ReturnCallIndirect` still pops at
+            // runtime, after the drop/keep shuffle has already run
             drop_keep.keep += 1;
             builder.bump_fuel_consumption(|| FuelCosts::CALL)?;
             drop_keep.translate_drop_keep(

--- a/src/vm/call_stack.rs
+++ b/src/vm/call_stack.rs
@@ -28,8 +28,6 @@ impl CallStack {
     }
 
     pub fn reset(&mut self) {
-        unsafe {
-            self.buf.set_len(0);
-        }
+        self.buf.clear();
     }
 }

--- a/src/vm/store.rs
+++ b/src/vm/store.rs
@@ -224,8 +224,12 @@ impl<T: 'static> RwasmStore<T> {
     /// Returns the raw 32-bit "global word" at the given internal index.
     ///
     /// rwasm stores globals as 32-bit words. `i64`/`f64` globals occupy **two** words:
-    /// - low word at `global_index * 2`
-    /// - high word at `global_index * 2 + 1`
+    /// - high word at `global_index * 2`
+    /// - low word at `global_index * 2 + 1`
+    ///
+    /// The ordering is inherited from `SegmentBuilder::add_global_variable`, which pushes
+    /// `(lower, upper)` and therefore stores `upper` first; `visit_global_get`/`visit_global_set`
+    /// follow the same convention.
     ///
     /// This accessor is intended for differential fuzzing/oracles.
     pub fn global_word_bits(&self, global_word_index: u32) -> u32 {


### PR DESCRIPTION
Closes the four remaining low-severity sub-tasks of the [rWasm Audit 2026-08-27](https://linear.app/fluentlabs-xyz/issue/FLU-1212/rwasm-audit-2026-08-27) (FLU-1212). One commit per sub-task.

| Commit | Issue | Area |
| -- | -- | -- |
| `docs(vm): correct hi/lo word order in global_word_bits doc comment` | FLU-1215 | `src/vm/store.rs` |
| `fix(compiler): fail closed when active data-segment page math overflows` | FLU-1216 | `src/compiler/segment_builder.rs` |
| `refactor(vm): replace unsafe set_len(0) with clear in CallStack::reset` | FLU-1217 | `src/vm/call_stack.rs` |
| `docs(compiler): explain the drop_keep.keep += 1 in visit_return_call_indirect` | FLU-1218 | `src/compiler/translator.rs` |

## FLU-1215 — inverted hi/lo doc

The doc comment on `global_word_bits` claimed the low word sits at `global_index * 2`. The real layout is the reverse: `add_global_variable` pushes `(lower, upper)` so `upper` is stored first, and `visit_global_get`/`visit_global_set` both follow that order. Swapped the bullets and noted where the ordering comes from — the naming is genuinely counter-intuitive, and this is the doc a differential-oracle author reads.

Documentation only.

## FLU-1216 — overflow guard failed open

`has_memory_overflow` returns `None` only when the `u32` page arithmetic overflows, which is the strongest evidence a segment is out of range. `unwrap_or_default()` mapped that to `false` ("no overflow"), skipping the `u32::MAX` length that forces the instantiation trap.

Now `unwrap_or(true)`. Also dropped the `checked_div` — the divisor is a nonzero constant, so only the two adds are genuinely fallible.

Not exploitable today: any offset large enough to wrap is rejected by `visit_memory_init`'s destination bounds check, so instantiation traps either way and the observable behaviour is unchanged. This removes the latent hazard of a guard that is load-bearing in intent but not in fact.

## FLU-1217 — avoidable `unsafe`

`buf` is a `SmallVec<[InstructionPtr; 16]>` and `InstructionPtr` is `#[repr(transparent)]` over a raw pointer — `Copy`, no `Drop` — so truncating to zero has no elements to drop and `clear()` lowers to the same code. `reset` runs on every trap and at the end of every `run_with_stack_check`, so this drops an `unsafe` block from a hot path for nothing.

## FLU-1218 — stale TODO

The TODO asked whether `drop_keep_return_call` had a bug. It does not. The `+ 1` compensates for the `stack_height.pop1()` two lines above, which removes the func index from the emulated height while the runtime stack still carries it.

With `H` runtime slots above the frame base (func index included), `P` lowered param slots and `L` registered locals, `drop_keep_return_call` computes `drop = (H - 1) - P + L`, which equals the required `H + L - (P + 1)` for a tail call retaining params plus the func index. Bumping `keep` to `P + 1` lines both halves up.

Replaced the TODO with that explanation. The optional `checked_add` hardening was skipped — `keep` is a `u16` and `P` is bounded by validation far below `u16::MAX`.

## Testing

* `cargo test` (root) — all suites pass, 0 failures
* `cargo test` (e2e) — 92/92 spec tests pass, including `wasm_return_call_indirect`
* `cargo fmt --check` and `cargo clippy --all-targets` clean

Only FLU-1216 touches emitted bytecode, and only on an input that already traps at instantiation; the other three are comment and hygiene changes with no behavioural effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of oversized memory calculations so out-of-range values trigger the correct runtime trap instead of being accepted.
  - Preserved function references correctly during indirect tail calls.
  - Improved call-stack reset safety, reducing the risk of stale execution state.

- **Documentation**
  - Corrected documentation describing the storage order of 64-bit global values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->