### PR TITLE
perf(bench): drop fib's 1 MiB shadow stack and split warm/cold paths

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -1,30 +1,73 @@
-In these benchmarks, we emulate the Ethereum execution environment, where a smart contract must be loaded from its
-binary representation before execution.
+# Benchmarks
 
-The binary can be loaded either from a cache or directly from the state trie.
-If we load the binary from the state, we need to parse, verify, and execute it (optionally caching it afterward).
-For cached binaries, only execution is required.
+These benchmarks model the two ways an execution environment reaches a contract, following the
+Ethereum pattern: either the module is already instantiated and cached, or it has to be loaded and
+instantiated from the state trie on every call.
 
-**Current results:**
+The two cases have very different costs, so each backend is measured both ways:
 
-| Test    | Native | rWasm | rWasm (no-cache) | Wasmi | Wasmi (no-cache) |
-|---------|--------|-------|------------------|-------|------------------|
-| fib(47) | 12ns   | 484ns | 879ns            | 341ns | 5379ns           |
+- **warm** — instantiation is hoisted out of the measured loop; only execution is timed.
+- **cold** — a fresh store and instance per iteration, then execution.
 
-Tested on Apple M3 MAX.
+Both backends meter fuel, so neither is credited for skipping work the other does.
 
-**PS:** We also benchmarked SP1's RISC-V implementation but removed it from the table since it was too slow (\~7 ms for
-fib).
+## Running
 
----
+```bash
+cargo bench --bench bench
+```
 
-rWasm delivers performance very close to Wasmi (the minor difference is due to the entrypoint logic that rWasm
-requires).
-This happens because rWasm has a dedicated function to initialize all necessary data, and this data is reset before each
-benchmark iteration.
-Wasmi caches initialization as well, which is why it sometimes appears faster.
+## Current results
 
-In practice, the most common scenario is execution without cache ("no-cache").
-In this case, rWasm shows significant performance improvements over Wasmi (up to 10x faster).
-There are techniques available to further reduce binary decoding costs, but they haven’t been applied yet.
-With optimized binary decoding, execution time could be as low as \~400–500 ns.
+`fib(43)`, Apple M5 Max:
+
+| Backend            | warm    | cold    |
+|--------------------|---------|---------|
+| Native Rust        | 10.5 ns | —       |
+| rWasm interpreter  | 322 ns  | 476 ns  |
+| Wasmtime (JIT)     | 109 ns  | 5.48 µs |
+
+Wasmtime executes compiled code, so it wins the warm row by roughly 3x; rWasm is an interpreter and
+that gap is expected. The order reverses on the cold row, where Wasmtime's store and instance
+construction costs about 5 µs, an order of magnitude more than an entire rWasm call.
+
+## What these numbers do not tell you
+
+`fib` is a 43-iteration integer loop. It measures interpreter dispatch and instantiation overhead,
+not the memory traffic, host calls, or control flow of a real contract.
+
+The cold row in particular is a floor rather than a typical figure. `examples/fib` is linked with a
+zero-sized shadow stack (`-zstack-size=0`), so it declares a zero-page linear memory and
+instantiation allocates nothing. A real module declares real memory, and cold instantiation then
+pays to allocate and zero it — about 4 µs for the 1 MiB shadow stack `wasm-ld` reserves by default,
+which on its own dwarfs everything in the table above.
+
+## Why the warm row needs care
+
+A warm executor is only meaningful because `fib` is pure integer arithmetic that leaves no guest
+state behind. Reusing an executor is not a general-purpose mode, and the benchmark should not be
+read as a claim that it is.
+
+`StrategyExecutor::execute` performs no reset. The interpreter's own value and call stacks are
+rebuilt on every call, so those are never the problem — but everything on the guest side survives:
+mutable globals, linear memory, dropped data and element segment flags, and consumed fuel.
+
+The sharp edge is a trap. A guest that traps mid-call never restores its shadow stack pointer, and
+because nothing resets that global, every later call starts from the corrupted value and never
+recovers. Measured on a module that decrements a shadow stack pointer and traps before restoring
+it:
+
+```
+clean warm runs        sp = 65536, 65536, 65536
+a run that traps       Err(UnreachableCodeReached)
+warm runs after that   sp = 65520, 65520, 65520   <- permanently shifted
+```
+
+`RwasmStore::reset(false)` followed by re-running the entrypoint does restore globals and re-apply
+data segments, which brings that example back to 65536. It does not zero linear memory: bytes
+written outside a data segment survive the reset. There is no cheaper path back to a genuinely
+clean instance than building one, which is exactly what the cold row measures.
+
+So the warm row is a fair microbenchmark of execution throughput on a self-contained, non-trapping
+kernel, and nothing more. Anything that traps, mutates memory, or depends on fresh globals has to
+use the cold path.

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,16 +2,58 @@ use criterion::{criterion_main, Bencher, Criterion};
 use fib_example::FIB_WASM;
 use rwasm::{
     always_failing_syscall_handler, wasmtime::compile_wasmtime_module, CompilationConfig,
-    ExecutionEngine, ImportLinker, RwasmModule, StrategyDefinition, Value,
+    ExecutionEngine, ImportLinker, RwasmModule, StrategyDefinition, StrategyExecutor, Value,
 };
 use std::{sync::Arc, time::Duration};
 
 const FIB_VALUE: i32 = 43;
+const FIB_RESULT: i32 = 433494437;
+
+fn create_executor(strategy: &StrategyDefinition) -> StrategyExecutor<()> {
+    strategy
+        .create_executor(
+            Arc::new(ImportLinker::default()),
+            (),
+            always_failing_syscall_handler,
+            // The warm benchmarks never reset fuel, so a finite limit would be exhausted partway
+            // through a measurement and turn into an `OutOfFuel` panic.
+            Some(u64::MAX),
+            None,
+        )
+        .unwrap()
+}
+
+fn run(executor: &mut StrategyExecutor<()>) {
+    let mut result = [Value::I32(0)];
+    executor
+        .execute("main", &[Value::I32(FIB_VALUE)], &mut result)
+        .unwrap();
+    // A warm executor carries guest state between runs, so check the result rather than only the
+    // absence of a trap: silent drift would otherwise look like a faster benchmark.
+    assert_eq!(result[0].i32(), Some(FIB_RESULT));
+}
+
+/// Execution against an already-instantiated module: the cached-contract path.
+///
+/// Only sound because `fib` is pure integer arithmetic that leaves no guest state behind. See
+/// `benches/README.md` for why this does not generalize.
+fn bench_warm(b: &mut Bencher, strategy: StrategyDefinition) {
+    let mut executor = create_executor(&strategy);
+    b.iter(|| run(&mut executor));
+}
+
+/// A fresh store and instance per iteration: the state-trie path, and the one that matches how a
+/// blockchain execution environment actually calls a contract.
+fn bench_cold(b: &mut Bencher, strategy: StrategyDefinition) {
+    b.iter(|| {
+        let mut executor = create_executor(&strategy);
+        run(&mut executor);
+    });
+}
 
 fn bench_comparisons(c: &mut Criterion) {
     let mut group = c.benchmark_group("Comparisons");
 
-    // bench_native
     {
         pub fn fib(n: i32) -> i32 {
             let (mut a, mut b) = (0, 1);
@@ -29,60 +71,34 @@ fn bench_comparisons(c: &mut Criterion) {
         });
     };
 
-    fn bench_strategy(b: &mut Bencher, strategy: StrategyDefinition) {
-        b.iter(|| {
-            let mut executor = strategy
-                .create_executor(
-                    Arc::new(ImportLinker::default()),
-                    (),
-                    always_failing_syscall_handler,
-                    Some(1_000_000_000),
-                    None,
-                )
-                .unwrap();
-            let mut result = [Value::I32(0)];
-            executor
-                .execute("main", &[Value::I32(FIB_VALUE)], &mut result)
-                .unwrap();
-            core::hint::black_box(result);
-        });
-    }
-
     {
+        // Both backends meter fuel, otherwise the comparison rewards rwasm for doing less work.
         let config = CompilationConfig::default().with_consume_fuel(true);
         let module = compile_wasmtime_module(config, FIB_WASM).unwrap();
-        group.bench_function("bench_strategy_wasmtime", |b| {
-            let strategy = StrategyDefinition::Wasmtime {
-                module: module.clone(),
-            };
-            bench_strategy(b, strategy);
+        let strategy = StrategyDefinition::Wasmtime { module };
+        group.bench_function("bench_wasmtime_warm", |b| {
+            bench_warm(b, strategy.clone());
+        });
+        group.bench_function("bench_wasmtime_cold", |b| {
+            bench_cold(b, strategy.clone());
         });
     }
-
-    // {
-    //     let wasm_binary = include_bytes!("../lib.wasm");
-    //     let config = CompilationConfig::default().with_consume_fuel(true);
-    //     let module = compile_wasmi_module(config, wasm_binary).unwrap();
-    //     group.bench_function("bench_strategy_wasmi", |b| {
-    //         let strategy = StrategyDefinition::Wasmi {
-    //             module: module.clone(),
-    //         };
-    //         bench_strategy(b, strategy);
-    //     });
-    // }
 
     {
         let config = CompilationConfig::default()
             .with_entrypoint_name("main".into())
             .with_allow_malformed_entrypoint_func_type(true)
-            .with_consume_fuel(false);
+            .with_consume_fuel(true);
         let (module, _) = RwasmModule::compile(config, FIB_WASM).unwrap();
-        group.bench_function("bench_strategy_rwasm", |b| {
-            let strategy = StrategyDefinition::Rwasm {
-                module: module.clone(),
-                engine: ExecutionEngine::acquire_shared(),
-            };
-            bench_strategy(b, strategy);
+        let strategy = StrategyDefinition::Rwasm {
+            module,
+            engine: ExecutionEngine::acquire_shared(),
+        };
+        group.bench_function("bench_rwasm_warm", |b| {
+            bench_warm(b, strategy.clone());
+        });
+        group.bench_function("bench_rwasm_cold", |b| {
+            bench_cold(b, strategy.clone());
         });
     }
 

--- a/examples/fib/build.rs
+++ b/examples/fib/build.rs
@@ -43,10 +43,21 @@ fn main() {
     // cargo b --bin fib --release --target=wasm32-unknown-unknown --no-default-features
     //
     // NOTE: "cargo b" is likely an alias; here we call "cargo build".
+    // `fib` is pure integer arithmetic and never spills to the shadow stack, so we size that stack
+    // to zero. Otherwise wasm-ld reserves its default 1 MiB, which reaches the module as a 16-page
+    // minimum memory that every instantiation must allocate and zero (~4 us), swamping the ~300 ns
+    // of execution the benchmark is meant to measure.
+    //
+    // This holds only while `main.rs` stays free of stack-allocated data: anything that spills will
+    // trap against a zero-page linear memory.
     let status = Command::new("cargo")
         .current_dir(&manifest_dir)
         .env(GUARD, "1")
         .env("CARGO_TARGET_DIR", &inner_target_dir)
+        // Cargo hands build scripts a `CARGO_ENCODED_RUSTFLAGS` that would take precedence over
+        // `RUSTFLAGS` in the inner build, so drop it first.
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+        .env("RUSTFLAGS", "-C link-arg=-zstack-size=0")
         .arg("build")
         .arg("--bin")
         .arg("fib")


### PR DESCRIPTION
## Why

`benches/README.md` advertised `fib(47)` at **484ns** for rWasm while the benchmark reported ~4.5µs. The VM had not regressed.

The table was measured in May 2025 against `benchmarks/bench.rs`, which built the store and engine **outside** `b.iter` — its 484ns row timed execution against an already-instantiated module. When the benchmark was rewritten for Criterion (`ece6e9ba`), the README was copied over verbatim while the harness moved instantiation **inside** the loop. The two have described different work ever since.

Verified by running the unmodified benchmark at `ece6e9ba` — the commit that introduced the table — and at `HEAD`, back to back on the same machine: **5.02µs** then, **4.53µs** now. `HEAD` is ~10% faster than the day the "484ns" table landed.

## What was actually slow

`wasm-ld` reserves a 1 MiB shadow stack by default, which reaches the module as a 16-page minimum linear memory. `fib` is pure integer arithmetic and never touches it, but every instantiation still allocated and zeroed that megabyte.

Phase breakdown before this change:

| Phase | Time |
|---|---|
| full iteration | 4.58 µs |
| `create_executor` only | 4.21 µs |
| `execute` only, reused executor | 0.31 µs |
| raw 1 MiB alloc + zero (baseline) | 4.09 µs |

## Changes

**`examples/fib/build.rs`** — link with `-zstack-size=0`, so the module declares a zero-page memory and instantiation allocates nothing. Cold instantiation plus execution: **4.5µs → 476ns**.

`.env_remove("CARGO_ENCODED_RUSTFLAGS")` is load-bearing: Cargo hands build scripts an encoded copy that takes precedence over `RUSTFLAGS` in the inner build, so the flag is silently ignored without it.

**`benches/bench.rs`** — warm and cold variants for both backends. Both now meter fuel, so neither is credited for skipping the other's work (metering costs rWasm ~3–4%, measured). Fuel limit raised to `u64::MAX`: the warm loops never reset it, and the previous `1_000_000_000` against Wasmtime's 213 fuel/run would have hit `OutOfFuel` and panicked after ~4.7M iterations. The result is now asserted rather than merely unwrapped, since a warm executor carries guest state and silent drift would read as a speedup. Removed a commented-out wasmi block referencing a `../lib.wasm` and a `compile_wasmi_module` that do not exist.

**`benches/README.md`** — rewritten around the same split. Dropped the wasmi columns, the SP1 footnote and the decoding-cost projections; none are measured here. Corrected the host, which was inherited from the 2025 table.

## Results

`fib(43)`, Apple M5 Max:

| Backend | warm | cold |
|---|---|---|
| Native Rust | 10.5 ns | — |
| rWasm interpreter | 322 ns | 476 ns |
| Wasmtime (JIT) | 109 ns | 5.48 µs |

Wasmtime takes the warm row ~3x (JIT vs interpreter, expected). rWasm takes the cold row by an order of magnitude — an entire rWasm call costs less than Wasmtime's store construction.

## On warm benchmarks

The README documents why the warm row is sound here and not in general. `StrategyExecutor::execute` performs no reset. The interpreter's own value and call stacks are rebuilt per call, so those are never the issue — but guest state survives: mutable globals, linear memory, segment-drop flags, consumed fuel.

A guest that traps never restores its shadow stack pointer, and nothing resets that global:

```
clean warm runs        sp = 65536, 65536, 65536
a run that traps       Err(UnreachableCodeReached)
warm runs after that   sp = 65520, 65520, 65520   <- never recovers
```

`RwasmStore::reset(false)` plus re-running the entrypoint restores globals and re-applies data segments, but does not zero linear memory — bytes written outside a data segment survive. Building a fresh instance is the only clean path, which is what the cold row measures.

## Caveat

The cold row is a floor, not a typical figure: a real module declares real memory and pays to allocate and zero it. The README says so.

## Testing

Full suite passes, `cargo clippy --benches` and `cargo fmt --check` clean.

One pre-existing failure on `devel`, untouched by this PR: `max_stack_height_records_the_peak_not_the_current_height` (`tests/value-stack-api.rs:51`). Verified failing with the original `build.rs` in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark documentation to compare warm and cold execution paths across Native Rust, rWasm, and Wasmtime.
  * Added context on benchmark limitations and when warm execution results are applicable.

* **Tests**
  * Expanded benchmarks to cover cached and fresh execution scenarios.
  * Added result validation and updated execution metering for more reliable measurements.

* **Chores**
  * Optimized the Fibonacci example’s WebAssembly build configuration by removing unnecessary stack reservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->