### PR TITLE
fix(compiler): enforce function type compilation limits

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -18,6 +18,23 @@ Key responsibilities:
 - emit compact opcode stream (`Opcode` enum)
 - emit metadata needed for runtime (signatures, globals, segments)
 
+`CompilationConfig::max_allowed_function_types` limits the declared type-section entry count to
+4,096 by default, including duplicate signatures. `ModuleParser` checks this before wasmparser
+allocates type storage and before rWasm's signature deduplication scans earlier entries. Oversized
+sections return `CompilationError::TooManyFunctionTypes { count, limit }`; exactly the limit is
+accepted. The default bounds deduplication to at most 8,386,560 signature comparisons per module.
+
+Hosts can set an explicit limit with `with_max_allowed_function_types(...)`; raising it requires a
+matching compilation resource budget. The rule applies to all rWasm compilation and export-parsing
+entrypoints, independently of runtime fuel metering. Accepted modules retain their generated
+bytecode and codegen identity: this is an input-validation rule, not a code-generation change.
+The Wasmtime adapter still requires callers to validate untrusted input with rWasm's compilation
+rules first, as documented on `StrategyDefinition::new_as_wasmtime`.
+
+Integrations adopting this compiler must coordinate the new default as an input-compatibility
+change. On-chain compilers must be rebuilt and upgraded to activate it; already compiled rWasm
+artifacts are unchanged.
+
 ## 3) Module construction
 
 `src/module/**` materializes `RwasmModule` / builder outputs:

--- a/src/compiler/config.rs
+++ b/src/compiler/config.rs
@@ -67,6 +67,11 @@ pub struct CompilationConfig {
     pub allow_start_section: bool,
     /// The maximum number of memory pages that can be allocated by the module.
     pub max_allowed_memory_pages: u32,
+    /// Maximum entries in the Wasm function-type section, including duplicates (default: 4096).
+    /// Checked before type validation allocates memory or signature deduplication runs.
+    /// Increasing this limit permits more quadratic compilation work and should be coordinated
+    /// with the host's compilation budget. It does not change emitted bytecode.
+    pub max_allowed_function_types: u32,
 }
 
 /// The default config maximizes rwasm-side metering: it enables
@@ -89,6 +94,7 @@ impl Default for CompilationConfig {
             allow_func_ref_function_types: false,
             allow_start_section: false,
             max_allowed_memory_pages: N_DEFAULT_MAX_MEMORY_PAGES,
+            max_allowed_function_types: 4096,
         }
     }
 }
@@ -235,6 +241,11 @@ impl CompilationConfig {
 
     pub fn with_max_allowed_memory_pages(mut self, max_allowed_memory_pages: u32) -> Self {
         self.max_allowed_memory_pages = max_allowed_memory_pages;
+        self
+    }
+
+    pub fn with_max_allowed_function_types(mut self, max_allowed_function_types: u32) -> Self {
+        self.max_allowed_function_types = max_allowed_function_types;
         self
     }
 }

--- a/src/compiler/error.rs
+++ b/src/compiler/error.rs
@@ -24,6 +24,7 @@ pub enum CompilationError {
     MemoryOutOfBounds,
     TableOutOfBounds,
     StartSectionsAreNotAllowed,
+    TooManyFunctionTypes { count: u32, limit: u32 },
 }
 
 impl core::error::Error for CompilationError {}
@@ -65,6 +66,12 @@ impl core::fmt::Display for CompilationError {
             CompilationError::TableOutOfBounds => write!(f, "out of bounds table access"),
             CompilationError::StartSectionsAreNotAllowed => {
                 write!(f, "start sections are not allowed")
+            }
+            CompilationError::TooManyFunctionTypes { count, limit } => {
+                write!(
+                    f,
+                    "function type count {count} exceeds compilation limit {limit}"
+                )
             }
         }
     }

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -423,8 +423,16 @@ impl ModuleParser {
     ///
     /// # Errors
     ///
-    /// If an unsupported function type is encountered.
+    /// If the configured type count limit is exceeded or an unsupported function type is encountered.
     fn process_types(&mut self, section: TypeSectionReader) -> Result<(), CompilationError> {
+        // Validation reserves storage for the declared count; bound it before that allocation
+        // and before the registry's quadratic signature-deduplication scan.
+        if section.count() > self.config.max_allowed_function_types {
+            return Err(CompilationError::TooManyFunctionTypes {
+                count: section.count(),
+                limit: self.config.max_allowed_function_types,
+            });
+        }
         self.validator.type_section(&section)?;
         for func_type in section.into_iter() {
             let Type::Func(func_type) = func_type?;

--- a/tests/compilation_limits.rs
+++ b/tests/compilation_limits.rs
@@ -1,0 +1,125 @@
+use rwasm::{CompilationConfig, CompilationError, ModuleParser, RwasmModule, StrategyDefinition};
+
+fn config() -> CompilationConfig {
+    CompilationConfig::default().with_entrypoint_name("main".into())
+}
+
+fn module_with_distinct_types(count: u32) -> Vec<u8> {
+    let mut source = String::from("(module (type (func))");
+    for index in 1..count {
+        source.push_str("(type (func (param");
+        for bit in 0..13 {
+            source.push_str(if index & (1 << bit) == 0 {
+                " i32"
+            } else {
+                " i64"
+            });
+        }
+        source.push_str(")))");
+    }
+    source.push_str("(func (export \"main\") (type 0)))");
+    wat::parse_str(source).unwrap()
+}
+
+#[test]
+fn default_type_limit_rejects_large_valid_type_section() {
+    let wasm = module_with_distinct_types(4097);
+    let result = RwasmModule::compile(config(), &wasm);
+    assert!(matches!(
+        result,
+        Err(CompilationError::TooManyFunctionTypes {
+            count: 4097,
+            limit: 4096
+        })
+    ));
+}
+
+#[test]
+fn type_limit_is_inclusive_and_does_not_change_accepted_bytecode() {
+    let wasm = module_with_distinct_types(4096);
+    let strict = config();
+    let relaxed = config().with_max_allowed_function_types(8192);
+    assert_eq!(strict.codegen_identity(), relaxed.codegen_identity());
+    let (strict_module, _) = RwasmModule::compile(strict, &wasm).unwrap();
+    let (relaxed_module, _) = RwasmModule::compile(relaxed, &wasm).unwrap();
+    assert_eq!(strict_module.serialize(), relaxed_module.serialize());
+}
+
+#[test]
+fn explicit_type_limit_controls_acceptance() {
+    let wasm = module_with_distinct_types(3);
+    assert!(RwasmModule::compile(config().with_max_allowed_function_types(3), &wasm).is_ok());
+    assert!(matches!(
+        RwasmModule::compile(config().with_max_allowed_function_types(2), &wasm),
+        Err(CompilationError::TooManyFunctionTypes { count: 3, limit: 2 })
+    ));
+    // The large module from the regression is valid when the host explicitly permits it.
+    let wasm = module_with_distinct_types(4097);
+    assert!(RwasmModule::compile(config().with_max_allowed_function_types(4097), &wasm).is_ok());
+}
+
+#[test]
+fn oversized_count_is_rejected_before_type_body_validation() {
+    // A type section declaring u32::MAX entries with no body. The limit error must precede
+    // wasmparser's malformed-body error and its count-based storage reservation.
+    let wasm = b"\0asm\x01\0\0\0\x01\x05\xff\xff\xff\xff\x0f";
+    let err = RwasmModule::compile(config(), wasm).unwrap_err();
+    assert!(matches!(
+        err,
+        CompilationError::TooManyFunctionTypes {
+            count: u32::MAX,
+            limit: 4096
+        }
+    ));
+    assert_eq!(
+        err.to_string(),
+        "function type count 4294967295 exceeds compilation limit 4096"
+    );
+
+    let truncated = b"\0asm\x01\0\0\0\x01\x01\x01";
+    assert!(matches!(
+        RwasmModule::compile(config(), truncated),
+        Err(CompilationError::MalformedWasmBinary(_))
+    ));
+}
+
+#[test]
+fn export_parsing_and_strategy_construction_enforce_type_limit() {
+    let wasm = module_with_distinct_types(3);
+    let config = config()
+        .with_max_allowed_function_types(2)
+        .with_consume_fuel(false);
+    assert!(matches!(
+        ModuleParser::parse_function_exports(config.clone(), &wasm),
+        Err(CompilationError::TooManyFunctionTypes { count: 3, limit: 2 })
+    ));
+    assert!(matches!(
+        StrategyDefinition::new_as_rwasm(config, &wasm),
+        Err(CompilationError::TooManyFunctionTypes { count: 3, limit: 2 })
+    ));
+    assert_eq!(
+        CompilationConfig::default_strategy_compatible().max_allowed_function_types,
+        4096
+    );
+}
+
+#[test]
+fn duplicate_signatures_still_count_toward_limit() {
+    let wasm = wat::parse_str("(module (type (func)) (type (func)) (type (func)))").unwrap();
+    assert!(matches!(
+        ModuleParser::new(config().with_max_allowed_function_types(2)).parse(&wasm),
+        Err(CompilationError::TooManyFunctionTypes { count: 3, limit: 2 })
+    ));
+}
+
+#[test]
+fn zero_type_limit_accepts_only_type_free_modules() {
+    let config = config().with_max_allowed_function_types(0);
+    let empty = wat::parse_str("(module)").unwrap();
+    ModuleParser::new(config.clone()).parse(&empty).unwrap();
+    let wasm = module_with_distinct_types(1);
+    assert!(matches!(
+        RwasmModule::compile(config, &wasm),
+        Err(CompilationError::TooManyFunctionTypes { count: 1, limit: 0 })
+    ));
+}


### PR DESCRIPTION
The rWasm compiler scans earlier signatures for each type-section entry, so large sections can trigger quadratic compilation work. Add `CompilationConfig::max_allowed_function_types` (default 4,096) and reject larger declared counts in `ModuleParser::process_types` before wasmparser reserves type storage or signature deduplication runs.

Oversized sections return `TooManyFunctionTypes { count, limit }`. Hosts can configure an explicit limit. The exact limit remains valid, and accepted modules retain their bytecode and codegen identity. The rule also covers export parsing and the rWasm strategy's compilation path.

Fixes [FLU-1305](https://linear.app/fluentlabs-xyz/issue/FLU-1305/medium-on-chain-wasm-compiler-is-super-linear-ot-in-the-type-section).

Validation:

- Reproduced acceptance of a valid 4,097-type module before the fix.
- `RUSTC_WRAPPER= cargo test --no-default-features --features std --test compilation_limits --locked`: 7 passed.
- `RUSTC_WRAPPER= cargo test --release --test compilation_limits --locked`: 7 passed.
- `RUSTC_WRAPPER= make test`: passed, including the e2e suite, snippets, and release Nitro regressions (372 passing test executions across the workflow).
- `RUSTC_WRAPPER= make clippy`: passed for root, e2e, and snippets with all features.
- `RUSTC_WRAPPER= cargo check --lib --target wasm32-unknown-unknown --no-default-features --locked`: passed.
- Pinned-nightly formatting and `git diff --check`: passed.

GitHub CI: the three Clippy jobs passed; tests, coverage, and benchmarks are still running. Maintainer review is required before merge.

The implementation and regression tests are separate GPG-signed Conventional Commits. Integrating hosts must coordinate adoption of the default as an input-compatibility change; on-chain compilers need to be rebuilt and upgraded to activate it.
