### PR TITLE
perf(wasmtime): cut per-call overhead in the wasmtime backend

### DIFF
--- a/src/wasmtime/context.rs
+++ b/src/wasmtime/context.rs
@@ -4,6 +4,52 @@ use crate::{
 };
 use wasmtime::{AsContext, AsContextMut, StoreLimits};
 
+const ENGINE_FUEL_EXPECTED: &str = "wasmtime: fuel metering was enabled at store creation";
+
+/// Charges `delta` fuel against the engine counter or, when the engine does not meter fuel,
+/// against the soft counter kept in the context.
+pub(crate) fn try_consume_fuel<T: 'static>(
+    mut ctx: impl AsContextMut<Data = WrappedContext<T>>,
+    delta: u64,
+) -> Result<(), TrapCode> {
+    let mut ctx = ctx.as_context_mut();
+    if ctx.data().fuel_enabled {
+        let remaining_fuel = ctx.get_fuel().expect(ENGINE_FUEL_EXPECTED);
+        let new_fuel = remaining_fuel
+            .checked_sub(delta)
+            .ok_or(TrapCode::OutOfFuel)?;
+        ctx.set_fuel(new_fuel).expect(ENGINE_FUEL_EXPECTED);
+    } else if let Some(fuel) = ctx.data_mut().fuel.as_mut() {
+        *fuel = fuel.checked_sub(delta).ok_or(TrapCode::OutOfFuel)?;
+    }
+    Ok(())
+}
+
+/// Returns the remaining fuel from whichever counter is active, if any.
+pub(crate) fn remaining_fuel<T: 'static>(
+    ctx: impl AsContext<Data = WrappedContext<T>>,
+) -> Option<u64> {
+    let ctx = ctx.as_context();
+    if ctx.data().fuel_enabled {
+        ctx.get_fuel().ok()
+    } else {
+        ctx.data().fuel
+    }
+}
+
+/// Resets whichever counter is active to `new_fuel_limit`.
+pub(crate) fn reset_fuel<T: 'static>(
+    mut ctx: impl AsContextMut<Data = WrappedContext<T>>,
+    new_fuel_limit: u64,
+) {
+    let mut ctx = ctx.as_context_mut();
+    if ctx.data().fuel_enabled {
+        ctx.set_fuel(new_fuel_limit).expect(ENGINE_FUEL_EXPECTED);
+    } else {
+        ctx.data_mut().fuel = Some(new_fuel_limit);
+    }
+}
+
 pub struct WrappedContext<T: 'static> {
     pub(crate) syscall_handler: SyscallHandler<T>,
     /// Soft fuel counter used when the engine does not meter fuel itself.
@@ -76,38 +122,15 @@ impl<'a, T: 'static> StoreTr<T> for WasmtimeCaller<'a, T> {
     }
 
     fn try_consume_fuel(&mut self, delta: u64) -> Result<(), TrapCode> {
-        if self.caller.data().fuel_enabled {
-            let remaining_fuel = self.caller.get_fuel().unwrap_or_else(|_| {
-                unreachable!("wasmtime: fuel metering was enabled at store creation")
-            });
-            let new_fuel = remaining_fuel
-                .checked_sub(delta)
-                .ok_or(TrapCode::OutOfFuel)?;
-            self.caller.set_fuel(new_fuel).unwrap_or_else(|_| {
-                unreachable!("wasmtime: fuel metering was enabled at store creation")
-            });
-        } else if let Some(fuel) = self.caller.data_mut().fuel.as_mut() {
-            *fuel = fuel.checked_sub(delta).ok_or(TrapCode::OutOfFuel)?;
-        }
-        Ok(())
+        try_consume_fuel(&mut self.caller, delta)
     }
 
     fn remaining_fuel(&self) -> Option<u64> {
-        if self.caller.data().fuel_enabled {
-            self.caller.get_fuel().ok()
-        } else {
-            self.caller.data().fuel
-        }
+        remaining_fuel(&self.caller)
     }
 
     fn reset_fuel(&mut self, new_fuel_limit: u64) {
-        if self.caller.data().fuel_enabled {
-            self.caller.set_fuel(new_fuel_limit).unwrap_or_else(|_| {
-                unreachable!("wasmtime: fuel metering was enabled at store creation")
-            });
-        } else {
-            self.caller.data_mut().fuel = Some(new_fuel_limit)
-        }
+        reset_fuel(&mut self.caller, new_fuel_limit)
     }
 }
 

--- a/src/wasmtime/context.rs
+++ b/src/wasmtime/context.rs
@@ -6,7 +6,17 @@ use wasmtime::{AsContext, AsContextMut, StoreLimits};
 
 pub struct WrappedContext<T: 'static> {
     pub(crate) syscall_handler: SyscallHandler<T>,
+    /// Soft fuel counter used when the engine does not meter fuel itself.
     pub(crate) fuel: Option<u64>,
+    /// Whether the engine meters fuel for this store.
+    ///
+    /// Resolved once at store creation: probing `get_fuel()` on every fuel access builds an
+    /// error value each time metering is off, which is the common case for self-metered
+    /// runtimes.
+    pub(crate) fuel_enabled: bool,
+    /// The instance's exported memory, resolved once per instantiation so host calls don't
+    /// look it up by name.
+    pub(crate) memory: Option<wasmtime::Memory>,
     pub(crate) resource_limiter: StoreLimits,
     pub(crate) data: T,
 }
@@ -23,11 +33,8 @@ impl<'a, T: 'static> WasmtimeCaller<'a, T> {
         self.caller
     }
 
-    fn exported_memory(&mut self) -> Result<wasmtime::Memory, TrapCode> {
-        self.caller
-            .get_export("memory")
-            .and_then(|export| export.into_memory())
-            .ok_or(TrapCode::MemoryOutOfBounds)
+    fn exported_memory(&self) -> Result<wasmtime::Memory, TrapCode> {
+        self.caller.data().memory.ok_or(TrapCode::MemoryOutOfBounds)
     }
 }
 
@@ -69,13 +76,16 @@ impl<'a, T: 'static> StoreTr<T> for WasmtimeCaller<'a, T> {
     }
 
     fn try_consume_fuel(&mut self, delta: u64) -> Result<(), TrapCode> {
-        if let Ok(remaining_fuel) = self.caller.get_fuel() {
+        if self.caller.data().fuel_enabled {
+            let remaining_fuel = self.caller.get_fuel().unwrap_or_else(|_| {
+                unreachable!("wasmtime: fuel metering was enabled at store creation")
+            });
             let new_fuel = remaining_fuel
                 .checked_sub(delta)
                 .ok_or(TrapCode::OutOfFuel)?;
-            self.caller
-                .set_fuel(new_fuel)
-                .unwrap_or_else(|_| unreachable!("wasmtime: fuel mode is disabled in wasmtime"));
+            self.caller.set_fuel(new_fuel).unwrap_or_else(|_| {
+                unreachable!("wasmtime: fuel metering was enabled at store creation")
+            });
         } else if let Some(fuel) = self.caller.data_mut().fuel.as_mut() {
             *fuel = fuel.checked_sub(delta).ok_or(TrapCode::OutOfFuel)?;
         }
@@ -83,17 +93,18 @@ impl<'a, T: 'static> StoreTr<T> for WasmtimeCaller<'a, T> {
     }
 
     fn remaining_fuel(&self) -> Option<u64> {
-        if let Ok(fuel) = self.caller.get_fuel() {
-            Some(fuel)
+        if self.caller.data().fuel_enabled {
+            self.caller.get_fuel().ok()
         } else {
-            self.caller.data().fuel.as_ref().copied()
+            self.caller.data().fuel
         }
     }
 
     fn reset_fuel(&mut self, new_fuel_limit: u64) {
-        let has_fuel_enabled = self.caller.get_fuel().is_ok();
-        if has_fuel_enabled {
-            self.caller.set_fuel(new_fuel_limit).unwrap();
+        if self.caller.data().fuel_enabled {
+            self.caller.set_fuel(new_fuel_limit).unwrap_or_else(|_| {
+                unreachable!("wasmtime: fuel metering was enabled at store creation")
+            });
         } else {
             self.caller.data_mut().fuel = Some(new_fuel_limit)
         }

--- a/src/wasmtime/import_linker.rs
+++ b/src/wasmtime/import_linker.rs
@@ -10,12 +10,14 @@ use wasmparser::ValType;
 
 /// Whether a signature can go through the raw trampoline, which handles numeric values only.
 fn is_numeric_signature(params: &[ValType], result: &[ValType]) -> bool {
-    params.iter().chain(result).all(|ty| {
-        matches!(
-            ty,
-            ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64
-        )
-    })
+    params.iter().chain(result).all(is_numeric_type)
+}
+
+fn is_numeric_type(ty: &ValType) -> bool {
+    matches!(
+        ty,
+        ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64
+    )
 }
 
 /// Creates a Wasmtime linker from an rWasm `ImportLinker`.

--- a/src/wasmtime/import_linker.rs
+++ b/src/wasmtime/import_linker.rs
@@ -1,8 +1,22 @@
 use crate::{
-    wasmtime::{context::WrappedContext, types::map_val_type, wasmtime_syscall_handler},
+    wasmtime::{
+        context::WrappedContext, syscall_handler::wasmtime_syscall_handler_raw,
+        types::map_val_type, wasmtime_syscall_handler,
+    },
     ImportLinker,
 };
 use std::sync::Arc;
+use wasmparser::ValType;
+
+/// Whether a signature can go through the raw trampoline, which handles numeric values only.
+fn is_numeric_signature(params: &[ValType], result: &[ValType]) -> bool {
+    params.iter().chain(result).all(|ty| {
+        matches!(
+            ty,
+            ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64
+        )
+    })
+}
 
 /// Creates a Wasmtime linker from an rWasm `ImportLinker`.
 ///
@@ -33,8 +47,30 @@ pub fn wasmtime_import_linker<T: 'static>(
 
         let func_type = wasmtime::FuncType::new(engine, params, result);
 
-        linker
-            .func_new(
+        let linked = if is_numeric_signature(import_entity.params, import_entity.result) {
+            let sys_func_idx = import_entity.sys_func_idx;
+            let (param_types, result_types) = (import_entity.params, import_entity.result);
+            // SAFETY: `func_type` was built from exactly `param_types` and `result_types`,
+            // both numeric only, and the raw trampoline reads and writes the value slots
+            // according to those same slices.
+            unsafe {
+                linker.func_new_unchecked(
+                    import_name.module(),
+                    import_name.name(),
+                    func_type,
+                    move |caller, slots| {
+                        wasmtime_syscall_handler_raw(
+                            sys_func_idx,
+                            param_types,
+                            result_types,
+                            caller,
+                            slots,
+                        )
+                    },
+                )
+            }
+        } else {
+            linker.func_new(
                 import_name.module(),
                 import_name.name(),
                 func_type,
@@ -42,7 +78,8 @@ pub fn wasmtime_import_linker<T: 'static>(
                     wasmtime_syscall_handler(import_entity.sys_func_idx, caller, params, result)
                 },
             )
-            .unwrap_or_else(|_| panic!("function import collision: {}", import_name));
+        };
+        linked.unwrap_or_else(|_| panic!("function import collision: {}", import_name));
     }
 
     linker

--- a/src/wasmtime/instance.rs
+++ b/src/wasmtime/instance.rs
@@ -277,21 +277,21 @@ impl<T: 'static> WasmtimeExecutor<T> {
         // SAFETY: `slots` holds one initialized value per parameter, of the types recorded from
         // the function's own type when the export was cached, and has room for every result. The
         // function is numeric only, so no reference types need rooting.
-        unsafe { function.func.call_unchecked(&mut *store, &mut slots[..]) }
+        let halted = match unsafe { function.func.call_unchecked(&mut *store, &mut slots[..]) }
             .map_err(map_wasmtime_error)
-            .or_else(|trap_code| {
-                if trap_code == TrapCode::ExecutionHalted {
-                    Ok(())
-                } else {
-                    Err(trap_code)
-                }
-            })?;
+        {
+            Ok(()) => false,
+            Err(TrapCode::ExecutionHalted) => true,
+            Err(trap_code) => return Err(trap_code),
+        };
         for ((slot, out), ty) in slots.iter().zip(result.iter_mut()).zip(&function.results) {
+            // A halted call never wrote its results, so the slots still hold parameter bits;
+            // report zeros of the declared types instead of reinterpreting them.
             *out = match ty {
-                ValType::I32 => Value::I32(slot.get_i32()),
-                ValType::I64 => Value::I64(slot.get_i64()),
-                ValType::F32 => Value::F32(F32::from_bits(slot.get_f32())),
-                ValType::F64 => Value::F64(F64::from_bits(slot.get_f64())),
+                ValType::I32 => Value::I32(if halted { 0 } else { slot.get_i32() }),
+                ValType::I64 => Value::I64(if halted { 0 } else { slot.get_i64() }),
+                ValType::F32 => Value::F32(F32::from_bits(if halted { 0 } else { slot.get_f32() })),
+                ValType::F64 => Value::F64(F64::from_bits(if halted { 0 } else { slot.get_f64() })),
                 _ => unreachable!("wasmtime: raw call path taken for a non-numeric export"),
             };
         }

--- a/src/wasmtime/instance.rs
+++ b/src/wasmtime/instance.rs
@@ -4,8 +4,19 @@ use crate::{
     ImportLinker, SyscallHandler, TrapCode, Value, F32, F64, N_BYTES_PER_MEMORY_PAGE,
     N_DEFAULT_MAX_MEMORY_PAGES, N_MAX_ALLOWED_MEMORY_PAGES,
 };
+use smallvec::SmallVec;
 use std::sync::Arc;
-use wasmtime::{AsContext, AsContextMut, Extern, StoreContext, StoreContextMut};
+use wasmtime::{AsContext, AsContextMut, Extern, StoreContext, StoreContextMut, ValRaw, ValType};
+
+/// Type of an exported function, recorded once so calls can marshal values without `Val`.
+struct ExportedFunction {
+    name: Box<str>,
+    func: wasmtime::Func,
+    params: Vec<ValType>,
+    results: Vec<ValType>,
+    /// Whether every parameter and result is numeric, which the raw call path requires.
+    numeric: bool,
+}
 
 pub struct WasmtimeExecutor<T: 'static> {
     pub linker: wasmtime::Linker<WrappedContext<T>>,
@@ -18,7 +29,7 @@ pub struct WasmtimeExecutor<T: 'static> {
     cached_instance: wasmtime::Instance,
     /// Exported functions of `cached_instance`, resolved once so calls don't look them up by
     /// name. Entry points are few, so a linear scan beats hashing the name.
-    functions: Vec<(Box<str>, wasmtime::Func)>,
+    functions: Vec<ExportedFunction>,
 }
 
 impl<T: 'static> AsContext for WasmtimeExecutor<T> {
@@ -49,18 +60,39 @@ impl<T: 'static> WasmtimeExecutor<T> {
 
     /// Resolves the exported functions and the exported memory of `instance` once.
     fn refresh_exports(&mut self) {
-        self.functions.clear();
+        let mut functions = Vec::new();
         let mut memory = None;
         for export in self.instance.exports(&mut self.store) {
             let name = export.name();
             match export.into_extern() {
-                Extern::Func(func) => self.functions.push((name.into(), func)),
+                Extern::Func(func) => functions.push((Box::<str>::from(name), func)),
                 Extern::Memory(exported_memory) if name == "memory" => {
                     memory = Some(exported_memory)
                 }
                 _ => {}
             }
         }
+        self.functions = functions
+            .into_iter()
+            .map(|(name, func)| {
+                let ty = func.ty(&self.store);
+                let params = ty.params().collect::<Vec<_>>();
+                let results = ty.results().collect::<Vec<_>>();
+                let numeric = params.iter().chain(&results).all(|ty| {
+                    matches!(
+                        ty,
+                        ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64
+                    )
+                });
+                ExportedFunction {
+                    name,
+                    func,
+                    params,
+                    results,
+                    numeric,
+                }
+            })
+            .collect();
         self.store.data_mut().memory = memory;
         self.cached_instance = self.instance;
     }
@@ -166,12 +198,11 @@ impl<T: 'static> WasmtimeExecutor<T> {
     }
 
     /// Looks up an exported function in the cached export table.
-    fn exported_function(&mut self, func_name: &str) -> Option<wasmtime::Func> {
+    fn exported_function(&mut self, func_name: &str) -> Option<usize> {
         self.ensure_exports_current();
         self.functions
             .iter()
-            .find(|(name, _)| &**name == func_name)
-            .map(|(_, func)| *func)
+            .position(|function| &*function.name == func_name)
     }
 
     #[cfg(feature = "e2e")]
@@ -210,10 +241,71 @@ impl<T: 'static> WasmtimeExecutor<T> {
         params: &[Value],
         result: &mut [Value],
     ) -> Result<(), TrapCode> {
-        use wasmtime::Val;
-        let entrypoint = self
+        let index = self
             .exported_function(func_name)
             .ok_or(TrapCode::UnknownExternalFunction)?;
+        let function = &self.functions[index];
+        if function.numeric {
+            return Self::execute_raw(&mut self.store, function, params, result);
+        }
+        self.execute_checked(function.func, params, result)
+    }
+
+    /// Calls a numeric-only export through raw value slots, skipping `Val` marshalling.
+    fn execute_raw(
+        store: &mut wasmtime::Store<WrappedContext<T>>,
+        function: &ExportedFunction,
+        params: &[Value],
+        result: &mut [Value],
+    ) -> Result<(), TrapCode> {
+        // The checked call path reports a signature mismatch as a generic wasmtime error, which
+        // `map_wasmtime_error` turns into `IllegalOpcode`; keep that mapping.
+        if params.len() != function.params.len() || result.len() != function.results.len() {
+            return Err(TrapCode::IllegalOpcode);
+        }
+        let mut slots = SmallVec::<[ValRaw; 8]>::new();
+        for (value, ty) in params.iter().zip(&function.params) {
+            slots.push(match (value, ty) {
+                (Value::I32(value), ValType::I32) => ValRaw::i32(*value),
+                (Value::I64(value), ValType::I64) => ValRaw::i64(*value),
+                (Value::F32(value), ValType::F32) => ValRaw::f32(value.to_bits()),
+                (Value::F64(value), ValType::F64) => ValRaw::f64(value.to_bits()),
+                _ => return Err(TrapCode::IllegalOpcode),
+            });
+        }
+        slots.resize(params.len().max(result.len()), ValRaw::i32(0));
+        // SAFETY: `slots` holds one initialized value per parameter, of the types recorded from
+        // the function's own type when the export was cached, and has room for every result. The
+        // function is numeric only, so no reference types need rooting.
+        unsafe { function.func.call_unchecked(&mut *store, &mut slots[..]) }
+            .map_err(map_wasmtime_error)
+            .or_else(|trap_code| {
+                if trap_code == TrapCode::ExecutionHalted {
+                    Ok(())
+                } else {
+                    Err(trap_code)
+                }
+            })?;
+        for ((slot, out), ty) in slots.iter().zip(result.iter_mut()).zip(&function.results) {
+            *out = match ty {
+                ValType::I32 => Value::I32(slot.get_i32()),
+                ValType::I64 => Value::I64(slot.get_i64()),
+                ValType::F32 => Value::F32(F32::from_bits(slot.get_f32())),
+                ValType::F64 => Value::F64(F64::from_bits(slot.get_f64())),
+                _ => unreachable!("wasmtime: raw call path taken for a non-numeric export"),
+            };
+        }
+        Ok(())
+    }
+
+    /// Calls an export through wasmtime's checked `Val` interface; needed for reference types.
+    fn execute_checked(
+        &mut self,
+        entrypoint: wasmtime::Func,
+        params: &[Value],
+        result: &mut [Value],
+    ) -> Result<(), TrapCode> {
+        use wasmtime::Val;
         let mut buffer = Vec::<Val>::default();
         for (i, value) in params.iter().enumerate() {
             let value = match value {

--- a/src/wasmtime/instance.rs
+++ b/src/wasmtime/instance.rs
@@ -5,13 +5,20 @@ use crate::{
     N_DEFAULT_MAX_MEMORY_PAGES, N_MAX_ALLOWED_MEMORY_PAGES,
 };
 use std::sync::Arc;
-use wasmtime::{AsContext, AsContextMut, StoreContext, StoreContextMut};
+use wasmtime::{AsContext, AsContextMut, Extern, StoreContext, StoreContextMut};
 
 pub struct WasmtimeExecutor<T: 'static> {
     pub linker: wasmtime::Linker<WrappedContext<T>>,
     pub store: wasmtime::Store<WrappedContext<T>>,
     pub instance_pre: wasmtime::InstancePre<WrappedContext<T>>,
     pub instance: wasmtime::Instance,
+    /// The instance whose exports are currently cached in `functions` and in the store's
+    /// memory handle. Compared against `instance` before every use, so swapping `instance`
+    /// directly still resolves the right exports.
+    cached_instance: wasmtime::Instance,
+    /// Exported functions of `cached_instance`, resolved once so calls don't look them up by
+    /// name. Entry points are few, so a linear scan beats hashing the name.
+    functions: Vec<(Box<str>, wasmtime::Func)>,
 }
 
 impl<T: 'static> AsContext for WasmtimeExecutor<T> {
@@ -29,10 +36,33 @@ impl<T: 'static> AsContextMut for WasmtimeExecutor<T> {
 
 impl<T: 'static> WasmtimeExecutor<T> {
     fn exported_memory(&mut self) -> Result<wasmtime::Memory, TrapCode> {
-        self.instance
-            .get_export(self.store.as_context_mut(), "memory")
-            .and_then(|export| export.into_memory())
-            .ok_or(TrapCode::MemoryOutOfBounds)
+        self.ensure_exports_current();
+        self.store.data().memory.ok_or(TrapCode::MemoryOutOfBounds)
+    }
+
+    /// Re-resolves the cached exports when `instance` was replaced since the last use.
+    fn ensure_exports_current(&mut self) {
+        if self.cached_instance != self.instance {
+            self.refresh_exports();
+        }
+    }
+
+    /// Resolves the exported functions and the exported memory of `instance` once.
+    fn refresh_exports(&mut self) {
+        self.functions.clear();
+        let mut memory = None;
+        for export in self.instance.exports(&mut self.store) {
+            let name = export.name();
+            match export.into_extern() {
+                Extern::Func(func) => self.functions.push((name.into(), func)),
+                Extern::Memory(exported_memory) if name == "memory" => {
+                    memory = Some(exported_memory)
+                }
+                _ => {}
+            }
+        }
+        self.store.data_mut().memory = memory;
+        self.cached_instance = self.instance;
     }
 
     /// Creates an executor by instantiating an already-compiled Wasmtime module.
@@ -44,7 +74,8 @@ impl<T: 'static> WasmtimeExecutor<T> {
     /// import linker, and start sections (the one way a valid module can trap during
     /// instantiation) are rejected by default at compile time. So a failure here means the caller
     /// paired a module with the wrong import linker or bypassed compilation/validation, and we'd
-    /// rather crash loudly than continue with a half-linked instance.
+    /// rather crash loudly than continue with a half-linked instance. Use [`Self::try_new`] to
+    /// get the error instead.
     pub fn new(
         module: wasmtime::Module,
         import_linker: Arc<ImportLinker>,
@@ -53,6 +84,27 @@ impl<T: 'static> WasmtimeExecutor<T> {
         fuel_limit: Option<u64>,
         max_allowed_memory_pages: Option<u32>,
     ) -> Self {
+        Self::try_new(
+            module,
+            import_linker,
+            data,
+            syscall_handler,
+            fuel_limit,
+            max_allowed_memory_pages,
+        )
+        .unwrap_or_else(|err| panic!("wasmtime: can't instantiate module: {}", err))
+    }
+
+    /// Creates an executor by instantiating an already-compiled Wasmtime module, returning the
+    /// linking or instantiation error instead of panicking.
+    pub fn try_new(
+        module: wasmtime::Module,
+        import_linker: Arc<ImportLinker>,
+        data: T,
+        syscall_handler: SyscallHandler<T>,
+        fuel_limit: Option<u64>,
+        max_allowed_memory_pages: Option<u32>,
+    ) -> wasmtime::Result<Self> {
         let memory_pages = max_allowed_memory_pages
             .unwrap_or(N_DEFAULT_MAX_MEMORY_PAGES)
             .min(N_MAX_ALLOWED_MEMORY_PAGES);
@@ -66,14 +118,18 @@ impl<T: 'static> WasmtimeExecutor<T> {
         let context = WrappedContext {
             syscall_handler,
             fuel: None,
+            fuel_enabled: false,
+            memory: None,
             resource_limiter,
             data,
         };
         let mut store = wasmtime::Store::<WrappedContext<T>>::new(module.engine(), context);
         store.limiter(|ctx| &mut ctx.resource_limiter);
+        let fuel_enabled = store.get_fuel().is_ok();
+        store.data_mut().fuel_enabled = fuel_enabled;
         if let Some(fuel) = fuel_limit {
-            if store.get_fuel().is_ok() {
-                store.set_fuel(fuel).expect("wasmtime: fuel is not enabled");
+            if fuel_enabled {
+                store.set_fuel(fuel)?;
             } else {
                 store.data_mut().fuel = Some(fuel);
             }
@@ -84,18 +140,38 @@ impl<T: 'static> WasmtimeExecutor<T> {
         {
             Self::link_spectest_globals(&mut linker, &mut store);
         }
-        let instance_pre = linker
-            .instantiate_pre(&module)
-            .unwrap_or_else(|err| panic!("wasmtime: can't pre-instantiate module: {}", err));
-        let instance = instance_pre
-            .instantiate(store.as_context_mut())
-            .unwrap_or_else(|err| panic!("wasmtime: can't instantiate module: {}", err));
-        Self {
+        let instance_pre = linker.instantiate_pre(&module)?;
+        let instance = instance_pre.instantiate(store.as_context_mut())?;
+        let mut executor = Self {
             linker,
             store,
             instance_pre,
             instance,
-        }
+            cached_instance: instance,
+            functions: Vec::new(),
+        };
+        executor.refresh_exports();
+        Ok(executor)
+    }
+
+    /// Instantiates `module` in this executor's store with its linker, replacing the current
+    /// instance and its cached exports.
+    pub fn instantiate(&mut self, module: &wasmtime::Module) -> wasmtime::Result<()> {
+        let instance_pre = self.linker.instantiate_pre(module)?;
+        let instance = instance_pre.instantiate(self.store.as_context_mut())?;
+        self.instance_pre = instance_pre;
+        self.instance = instance;
+        self.refresh_exports();
+        Ok(())
+    }
+
+    /// Looks up an exported function in the cached export table.
+    fn exported_function(&mut self, func_name: &str) -> Option<wasmtime::Func> {
+        self.ensure_exports_current();
+        self.functions
+            .iter()
+            .find(|(name, _)| &**name == func_name)
+            .map(|(_, func)| *func)
     }
 
     #[cfg(feature = "e2e")]
@@ -136,8 +212,7 @@ impl<T: 'static> WasmtimeExecutor<T> {
     ) -> Result<(), TrapCode> {
         use wasmtime::Val;
         let entrypoint = self
-            .instance
-            .get_func(self.store.as_context_mut(), func_name)
+            .exported_function(func_name)
             .ok_or(TrapCode::UnknownExternalFunction)?;
         let mut buffer = Vec::<Val>::default();
         for (i, value) in params.iter().enumerate() {
@@ -256,13 +331,16 @@ impl<T> crate::StoreTr<T> for WasmtimeExecutor<T> {
     }
 
     fn try_consume_fuel(&mut self, delta: u64) -> Result<(), TrapCode> {
-        if let Ok(remaining_fuel) = self.store.get_fuel() {
+        if self.store.data().fuel_enabled {
+            let remaining_fuel = self.store.get_fuel().unwrap_or_else(|_| {
+                unreachable!("wasmtime: fuel metering was enabled at store creation")
+            });
             let new_fuel = remaining_fuel
                 .checked_sub(delta)
                 .ok_or(TrapCode::OutOfFuel)?;
-            self.store
-                .set_fuel(new_fuel)
-                .unwrap_or_else(|_| unreachable!("wasmtime: fuel mode is disabled in wasmtime"));
+            self.store.set_fuel(new_fuel).unwrap_or_else(|_| {
+                unreachable!("wasmtime: fuel metering was enabled at store creation")
+            });
         } else if let Some(fuel) = self.store.data_mut().fuel.as_mut() {
             *fuel = fuel.checked_sub(delta).ok_or(TrapCode::OutOfFuel)?;
         }
@@ -270,17 +348,18 @@ impl<T> crate::StoreTr<T> for WasmtimeExecutor<T> {
     }
 
     fn remaining_fuel(&self) -> Option<u64> {
-        if let Ok(fuel) = self.store.get_fuel() {
-            Some(fuel)
+        if self.store.data().fuel_enabled {
+            self.store.get_fuel().ok()
         } else {
-            self.store.data().fuel.as_ref().copied()
+            self.store.data().fuel
         }
     }
 
     fn reset_fuel(&mut self, new_fuel_limit: u64) {
-        let has_fuel_enabled = self.store.get_fuel().is_ok();
-        if has_fuel_enabled {
-            self.store.set_fuel(new_fuel_limit).unwrap();
+        if self.store.data().fuel_enabled {
+            self.store.set_fuel(new_fuel_limit).unwrap_or_else(|_| {
+                unreachable!("wasmtime: fuel metering was enabled at store creation")
+            });
         } else {
             self.store.data_mut().fuel = Some(new_fuel_limit)
         }

--- a/src/wasmtime/instance.rs
+++ b/src/wasmtime/instance.rs
@@ -423,37 +423,14 @@ impl<T> crate::StoreTr<T> for WasmtimeExecutor<T> {
     }
 
     fn try_consume_fuel(&mut self, delta: u64) -> Result<(), TrapCode> {
-        if self.store.data().fuel_enabled {
-            let remaining_fuel = self.store.get_fuel().unwrap_or_else(|_| {
-                unreachable!("wasmtime: fuel metering was enabled at store creation")
-            });
-            let new_fuel = remaining_fuel
-                .checked_sub(delta)
-                .ok_or(TrapCode::OutOfFuel)?;
-            self.store.set_fuel(new_fuel).unwrap_or_else(|_| {
-                unreachable!("wasmtime: fuel metering was enabled at store creation")
-            });
-        } else if let Some(fuel) = self.store.data_mut().fuel.as_mut() {
-            *fuel = fuel.checked_sub(delta).ok_or(TrapCode::OutOfFuel)?;
-        }
-        Ok(())
+        crate::wasmtime::context::try_consume_fuel(&mut self.store, delta)
     }
 
     fn remaining_fuel(&self) -> Option<u64> {
-        if self.store.data().fuel_enabled {
-            self.store.get_fuel().ok()
-        } else {
-            self.store.data().fuel
-        }
+        crate::wasmtime::context::remaining_fuel(&self.store)
     }
 
     fn reset_fuel(&mut self, new_fuel_limit: u64) {
-        if self.store.data().fuel_enabled {
-            self.store.set_fuel(new_fuel_limit).unwrap_or_else(|_| {
-                unreachable!("wasmtime: fuel metering was enabled at store creation")
-            });
-        } else {
-            self.store.data_mut().fuel = Some(new_fuel_limit)
-        }
+        crate::wasmtime::context::reset_fuel(&mut self.store, new_fuel_limit)
     }
 }

--- a/src/wasmtime/syscall_handler.rs
+++ b/src/wasmtime/syscall_handler.rs
@@ -2,8 +2,10 @@ use crate::{
     wasmtime::{context::WrappedContext, WasmtimeCaller},
     TrapCode, Value, F32, F64,
 };
+use core::mem::MaybeUninit;
 use smallvec::SmallVec;
-use wasmtime::Val;
+use wasmparser::ValType;
+use wasmtime::{Val, ValRaw};
 
 /// Wasmtime import trampoline that executes a single runtime syscall.
 ///
@@ -68,6 +70,81 @@ pub fn wasmtime_syscall_handler<'a, T: 'static>(
     // Terminate execution if requested.
     if should_terminate {
         return Err(wasmtime::Error::new(TrapCode::ExecutionHalted));
+    }
+
+    Ok(())
+}
+
+/// Wasmtime import trampoline over raw value slots, for imports whose signature is numeric only.
+///
+/// Reads the parameters straight out of the raw slots and writes the results back into them,
+/// skipping the per-value `Val` boxing the checked trampoline pays on both sides.
+///
+/// # Safety
+///
+/// `params` and `result` must be exactly the signature the import was registered with, and
+/// must contain numeric types only. Wasmtime then guarantees that the first `params.len()`
+/// slots hold initialized values of those types and that `slots` has room for the results,
+/// and this function writes exactly `result.len()` values of the declared result types.
+pub unsafe fn wasmtime_syscall_handler_raw<'a, T: 'static>(
+    sys_func_idx: u32,
+    params: &'static [ValType],
+    result: &'static [ValType],
+    caller: wasmtime::Caller<'a, WrappedContext<T>>,
+    slots: &mut [MaybeUninit<ValRaw>],
+) -> wasmtime::Result<()> {
+    let mut buffer = SmallVec::<[Value; 32]>::new();
+    for (slot, ty) in slots.iter().zip(params) {
+        // SAFETY: wasmtime initializes the parameter slots before invoking the host function.
+        let raw = unsafe { slot.assume_init_ref() };
+        buffer.push(match ty {
+            ValType::I32 => Value::I32(raw.get_i32()),
+            ValType::I64 => Value::I64(raw.get_i64()),
+            ValType::F32 => Value::F32(F32::from_bits(raw.get_f32())),
+            ValType::F64 => Value::F64(F64::from_bits(raw.get_f64())),
+            _ => unreachable!("wasmtime: raw trampoline registered for a non-numeric import"),
+        });
+    }
+    buffer.extend(core::iter::repeat_n(Value::I32(0), result.len()));
+
+    let (mapped_params, mapped_result) = buffer.split_at_mut(params.len());
+    let syscall_handler = caller.data().syscall_handler;
+    let mut caller_adapter = WasmtimeCaller::<'a>::wrap_typed(caller);
+    let syscall_result = syscall_handler(
+        &mut caller_adapter,
+        sys_func_idx,
+        mapped_params,
+        mapped_result,
+    );
+
+    // Treat `ExecutionHalted` as a controlled termination rather than a hard error.
+    let should_terminate = syscall_result
+        .map(|_| false)
+        .or_else(|trap_code| {
+            if trap_code == TrapCode::ExecutionHalted {
+                Ok(true)
+            } else {
+                Err(trap_code)
+            }
+        })
+        .map_err(wasmtime::Error::new)?;
+
+    // Terminate execution if requested; wasmtime discards the results of a failed host call.
+    if should_terminate {
+        return Err(wasmtime::Error::new(TrapCode::ExecutionHalted));
+    }
+
+    // A handler that produces a value of the wrong type must not reach wasm: the slot would be
+    // reinterpreted as the declared type.
+    for ((slot, value), ty) in slots.iter_mut().zip(mapped_result.iter()).zip(result) {
+        let raw = match (value, ty) {
+            (Value::I32(value), ValType::I32) => ValRaw::i32(*value),
+            (Value::I64(value), ValType::I64) => ValRaw::i64(*value),
+            (Value::F32(value), ValType::F32) => ValRaw::f32(value.to_bits()),
+            (Value::F64(value), ValType::F64) => ValRaw::f64(value.to_bits()),
+            _ => return Err(wasmtime::Error::new(TrapCode::BadSignature)),
+        };
+        slot.write(raw);
     }
 
     Ok(())

--- a/src/wasmtime/tests.rs
+++ b/src/wasmtime/tests.rs
@@ -810,3 +810,60 @@ fn test_wasmtime_caller_writes_guest_memory_through_the_cached_handle() {
         vec![9, 8, 7, 6]
     );
 }
+
+#[test]
+fn test_wasmtime_raw_imports_return_float_results() {
+    let wasm_binary = wat::parse_str(
+        r#"
+            (module
+              (func $f32r (import "host" "f32r") (result f32))
+              (func $f64r (import "host" "f64r") (result f64))
+              (func (export "main") (result f64)
+                (drop (call $f32r))
+                (call $f64r)
+              )
+            )
+            "#,
+    )
+    .unwrap();
+    let mut import_linker = ImportLinker::default();
+    import_linker.insert_function(
+        ImportName::new("host", "f32r"),
+        0x32,
+        SyscallFuelParams::default(),
+        &[],
+        &[wasmparser::ValType::F32],
+    );
+    import_linker.insert_function(
+        ImportName::new("host", "f64r"),
+        0x64,
+        SyscallFuelParams::default(),
+        &[],
+        &[wasmparser::ValType::F64],
+    );
+    let import_linker = Arc::new(import_linker);
+    let compilation_config = CompilationConfig::default().with_import_linker(import_linker.clone());
+    let module = compile_wasmtime_module(compilation_config, wasm_binary).unwrap();
+    let mut wasmtime_worker = WasmtimeExecutor::new(
+        module,
+        import_linker,
+        (),
+        |_caller, sys_func_idx, _params, result| -> Result<(), TrapCode> {
+            result[0] = match sys_func_idx {
+                0x32 => Value::F32(crate::F32::from_bits(1.5f32.to_bits())),
+                0x64 => Value::F64(crate::F64::from_bits((-2.25f64).to_bits())),
+                _ => unreachable!(),
+            };
+            Ok(())
+        },
+        Some(100_000),
+        None,
+    );
+
+    let mut result = [Value::F64(crate::F64::from_bits(0))];
+    wasmtime_worker.execute("main", &[], &mut result).unwrap();
+    assert_eq!(
+        result[0],
+        Value::F64(crate::F64::from_bits((-2.25f64).to_bits()))
+    );
+}

--- a/src/wasmtime/tests.rs
+++ b/src/wasmtime/tests.rs
@@ -505,6 +505,9 @@ fn get_test_numeric_marshalling_module() -> (Module, Arc<ImportLinker>) {
               (func (export "mix_params") (param i32 i64) (result i64)
                 (call $mix (local.get 0) (local.get 1) (f32.const 0) (f64.const 0))
               )
+              (func (export "pass_f32") (param f32) (result f32)
+                (local.get 0)
+              )
             )
             "#,
     )
@@ -592,6 +595,19 @@ fn test_wasmtime_numeric_exports_marshal_params_and_results() {
         .execute("widen", &[Value::I32(-1)], &mut result)
         .unwrap();
     assert_eq!(result[0], Value::I64(-1));
+
+    let mut result = [Value::F32(crate::F32::from_bits(0))];
+    wasmtime_worker
+        .execute(
+            "pass_f32",
+            &[Value::F32(crate::F32::from_bits(1.5f32.to_bits()))],
+            &mut result,
+        )
+        .unwrap();
+    assert_eq!(
+        result[0],
+        Value::F32(crate::F32::from_bits(1.5f32.to_bits()))
+    );
 
     // Mismatched arity or types are rejected before the call, as the checked path did.
     let mut result = [Value::I32(0)];
@@ -766,4 +782,31 @@ fn test_wasmtime_executor_reports_instantiation_errors() {
     assert!(wasmtime_worker.instantiate(&unlinked_module).is_err());
     wasmtime_worker.execute("read_ok", &[], &mut []).unwrap();
     assert_eq!(wasmtime_worker.data(), &[1, 2, 3, 4]);
+}
+
+#[test]
+fn test_wasmtime_caller_writes_guest_memory_through_the_cached_handle() {
+    let (module, import_linker) = get_test_memory_module();
+    let mut wasmtime_worker = WasmtimeExecutor::new(
+        module,
+        import_linker,
+        Vec::new(),
+        |caller, _sys_func_idx, params, _result| -> Result<(), TrapCode> {
+            let offset = params[0].i32().unwrap() as usize;
+            caller.memory_write(offset, &[9, 8, 7, 6])?;
+            assert_eq!(
+                caller.memory_write(N_BYTES_PER_MEMORY_PAGE as usize, &[1]),
+                Err(TrapCode::MemoryOutOfBounds)
+            );
+            Ok(())
+        },
+        Some(100_000),
+        None,
+    );
+
+    wasmtime_worker.execute("read_ok", &[], &mut []).unwrap();
+    assert_eq!(
+        wasmtime_worker.memory_read_into_vec(0, 4).unwrap(),
+        vec![9, 8, 7, 6]
+    );
 }

--- a/src/wasmtime/tests.rs
+++ b/src/wasmtime/tests.rs
@@ -333,3 +333,140 @@ fn test_wasmtime_caller_memory_read_into_vec_checks_bounds_before_allocating() {
         TrapCode::MemoryOutOfBounds
     );
 }
+
+fn get_test_module_without_engine_fuel() -> (Module, Arc<ImportLinker>) {
+    let wasm_binary = wat::parse_str(
+        r#"
+            (module
+              (memory (export "memory") 1)
+              (func (export "main"))
+            )
+            "#,
+    )
+    .unwrap();
+    let import_linker = Arc::new(ImportLinker::default());
+    let compilation_config = CompilationConfig::default()
+        .with_consume_fuel(false)
+        .with_import_linker(import_linker.clone());
+    (
+        compile_wasmtime_module(compilation_config, wasm_binary).unwrap(),
+        import_linker,
+    )
+}
+
+#[test]
+fn test_wasmtime_fuel_accessors_use_engine_metering_when_enabled() {
+    let (module, import_linker) = get_test_wasmtime_module();
+    let mut wasmtime_worker = WasmtimeExecutor::new(
+        module,
+        import_linker,
+        (),
+        |_caller, _sys_func_idx, _params, _result| -> Result<(), TrapCode> { Ok(()) },
+        Some(100_000),
+        None,
+    );
+
+    assert_eq!(wasmtime_worker.remaining_fuel(), Some(100_000));
+    wasmtime_worker.try_consume_fuel(10).unwrap();
+    assert_eq!(wasmtime_worker.store.get_fuel().unwrap(), 99_990);
+    assert_eq!(wasmtime_worker.remaining_fuel(), Some(99_990));
+    assert_eq!(
+        wasmtime_worker.try_consume_fuel(100_000).unwrap_err(),
+        TrapCode::OutOfFuel
+    );
+    wasmtime_worker.reset_fuel(5);
+    assert_eq!(wasmtime_worker.store.get_fuel().unwrap(), 5);
+    assert_eq!(wasmtime_worker.remaining_fuel(), Some(5));
+}
+
+#[test]
+fn test_wasmtime_fuel_accessors_use_soft_counter_when_engine_metering_is_off() {
+    let (module, import_linker) = get_test_module_without_engine_fuel();
+    let mut wasmtime_worker = WasmtimeExecutor::new(
+        module,
+        import_linker,
+        (),
+        |_caller, _sys_func_idx, _params, _result| -> Result<(), TrapCode> { Ok(()) },
+        Some(1_000),
+        None,
+    );
+
+    assert!(wasmtime_worker.store.get_fuel().is_err());
+    assert_eq!(wasmtime_worker.remaining_fuel(), Some(1_000));
+    wasmtime_worker.try_consume_fuel(600).unwrap();
+    assert_eq!(wasmtime_worker.remaining_fuel(), Some(400));
+    assert_eq!(
+        wasmtime_worker.try_consume_fuel(401).unwrap_err(),
+        TrapCode::OutOfFuel
+    );
+    wasmtime_worker.reset_fuel(7);
+    assert_eq!(wasmtime_worker.remaining_fuel(), Some(7));
+    wasmtime_worker.execute("main", &[], &mut []).unwrap();
+    assert_eq!(wasmtime_worker.remaining_fuel(), Some(7));
+}
+
+#[test]
+fn test_wasmtime_executor_exports_follow_the_instance() {
+    let (memory_module, import_linker) = get_test_memory_module();
+    let module_without_memory = Module::new(
+        memory_module.engine(),
+        wat::parse_str(
+            r#"
+            (module
+              (func $read (import "host" "read") (param i32 i32))
+              (func (export "read_missing_memory")
+                (i32.const 0)
+                (i32.const 1)
+                (call $read)
+              )
+            )
+            "#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let mut wasmtime_worker = WasmtimeExecutor::new(
+        memory_module.clone(),
+        import_linker,
+        Vec::new(),
+        read_memory_syscall,
+        Some(100_000),
+        None,
+    );
+    wasmtime_worker.execute("read_ok", &[], &mut []).unwrap();
+    assert_eq!(wasmtime_worker.data(), &[1, 2, 3, 4]);
+
+    // Re-instantiating through the executor swaps both the function table and the memory.
+    wasmtime_worker.instantiate(&module_without_memory).unwrap();
+    assert_eq!(
+        wasmtime_worker
+            .execute("read_missing_memory", &[], &mut [])
+            .unwrap_err(),
+        TrapCode::MemoryOutOfBounds
+    );
+    assert_eq!(
+        wasmtime_worker
+            .execute("read_ok", &[], &mut [])
+            .unwrap_err(),
+        TrapCode::UnknownExternalFunction
+    );
+    assert_eq!(
+        wasmtime_worker.memory_read_into_vec(0, 1).unwrap_err(),
+        TrapCode::MemoryOutOfBounds
+    );
+
+    // Replacing the public `instance` field directly must resolve the new exports as well.
+    let instance_pre = wasmtime_worker
+        .linker
+        .instantiate_pre(&memory_module)
+        .unwrap();
+    wasmtime_worker.instance = instance_pre
+        .instantiate(&mut wasmtime_worker.store)
+        .unwrap();
+    wasmtime_worker.execute("read_ok", &[], &mut []).unwrap();
+    assert_eq!(wasmtime_worker.data(), &[1, 2, 3, 4, 1, 2, 3, 4]);
+    assert_eq!(
+        wasmtime_worker.memory_read_into_vec(0, 4).unwrap(),
+        vec![1, 2, 3, 4]
+    );
+}

--- a/src/wasmtime/tests.rs
+++ b/src/wasmtime/tests.rs
@@ -790,7 +790,7 @@ fn test_wasmtime_caller_writes_guest_memory_through_the_cached_handle() {
     let mut wasmtime_worker = WasmtimeExecutor::new(
         module,
         import_linker,
-        Vec::new(),
+        Vec::<u8>::new(),
         |caller, _sys_func_idx, params, _result| -> Result<(), TrapCode> {
             let offset = params[0].i32().unwrap() as usize;
             caller.memory_write(offset, &[9, 8, 7, 6])?;

--- a/src/wasmtime/tests.rs
+++ b/src/wasmtime/tests.rs
@@ -338,13 +338,23 @@ fn get_test_module_without_engine_fuel() -> (Module, Arc<ImportLinker>) {
     let wasm_binary = wat::parse_str(
         r#"
             (module
+              (func $probe (import "host" "probe"))
               (memory (export "memory") 1)
               (func (export "main"))
+              (func (export "probe") (call $probe))
             )
             "#,
     )
     .unwrap();
-    let import_linker = Arc::new(ImportLinker::default());
+    let mut import_linker = ImportLinker::default();
+    import_linker.insert_function(
+        ImportName::new("host", "probe"),
+        0xef,
+        SyscallFuelParams::default(),
+        &[],
+        &[],
+    );
+    let import_linker = Arc::new(import_linker);
     let compilation_config = CompilationConfig::default()
         .with_consume_fuel(false)
         .with_import_linker(import_linker.clone());
@@ -492,6 +502,9 @@ fn get_test_numeric_marshalling_module() -> (Module, Arc<ImportLinker>) {
               (func (export "widen") (param i32) (result i64)
                 (i64.extend_i32_s (local.get 0))
               )
+              (func (export "mix_params") (param i32 i64) (result i64)
+                (call $mix (local.get 0) (local.get 1) (f32.const 0) (f64.const 0))
+              )
             )
             "#,
     )
@@ -636,4 +649,121 @@ fn test_wasmtime_raw_import_halt_is_a_controlled_exit() {
 
     let mut result = [Value::I64(0)];
     wasmtime_worker.execute("main", &[], &mut result).unwrap();
+    assert_eq!(result[0], Value::I64(0));
+
+    // The halted export never wrote its result, so the caller must not see the parameter bits
+    // that are still in the shared slots.
+    let mut result = [Value::I64(0)];
+    wasmtime_worker
+        .execute("mix_params", &[Value::I32(-1), Value::I64(5)], &mut result)
+        .unwrap();
+    assert_eq!(result[0], Value::I64(0));
+}
+
+#[test]
+fn test_wasmtime_caller_fuel_accessors_use_engine_metering_when_enabled() {
+    let (module, import_linker) = get_test_wasmtime_module();
+    let mut wasmtime_worker = WasmtimeExecutor::new(
+        module,
+        import_linker,
+        (),
+        |caller, _sys_func_idx, _params, _result| -> Result<(), TrapCode> {
+            let before = caller.remaining_fuel().unwrap();
+            caller.try_consume_fuel(1_000)?;
+            assert_eq!(caller.remaining_fuel(), Some(before - 1_000));
+            caller.reset_fuel(500);
+            assert_eq!(caller.remaining_fuel(), Some(500));
+            // Overspending the engine counter is reported, not saturated.
+            assert_eq!(
+                caller.try_consume_fuel(501).unwrap_err(),
+                TrapCode::OutOfFuel
+            );
+            Ok(())
+        },
+        Some(100_000),
+        None,
+    );
+
+    wasmtime_worker.execute("main", &[], &mut []).unwrap();
+    // Only the instructions after the import call are charged against the reset budget.
+    let remaining = wasmtime_worker.store.get_fuel().unwrap();
+    assert!(
+        (450..=500).contains(&remaining),
+        "remaining fuel {remaining}"
+    );
+}
+
+#[test]
+fn test_wasmtime_caller_fuel_accessors_use_soft_counter_when_engine_metering_is_off() {
+    let (module, import_linker) = get_test_module_without_engine_fuel();
+    let mut wasmtime_worker = WasmtimeExecutor::new(
+        module,
+        import_linker,
+        0u32,
+        |caller, _sys_func_idx, _params, _result| -> Result<(), TrapCode> {
+            match *caller.data() {
+                0 => {
+                    assert_eq!(caller.remaining_fuel(), Some(1_000));
+                    caller.try_consume_fuel(600)?;
+                    assert_eq!(caller.remaining_fuel(), Some(400));
+                    caller.reset_fuel(7);
+                    assert_eq!(caller.remaining_fuel(), Some(7));
+                    *caller.data_mut() = 1;
+                    Ok(())
+                }
+                _ => caller.try_consume_fuel(8),
+            }
+        },
+        Some(1_000),
+        None,
+    );
+
+    wasmtime_worker.execute("probe", &[], &mut []).unwrap();
+    assert_eq!(wasmtime_worker.remaining_fuel(), Some(7));
+    // The second probe overspends the soft counter, which surfaces as an out-of-fuel trap.
+    assert_eq!(
+        wasmtime_worker.execute("probe", &[], &mut []).unwrap_err(),
+        TrapCode::OutOfFuel
+    );
+}
+
+#[test]
+fn test_wasmtime_executor_reports_instantiation_errors() {
+    let (module, import_linker) = get_test_memory_module();
+    let unlinked_module = Module::new(
+        module.engine(),
+        wat::parse_str(
+            r#"
+            (module
+              (func $missing (import "missing" "import"))
+              (func (export "main") (call $missing))
+            )
+            "#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+
+    assert!(WasmtimeExecutor::try_new(
+        unlinked_module.clone(),
+        import_linker.clone(),
+        Vec::new(),
+        read_memory_syscall,
+        Some(100_000),
+        None,
+    )
+    .is_err());
+
+    // A failed re-instantiation leaves the executor on its previous instance.
+    let mut wasmtime_worker = WasmtimeExecutor::new(
+        module,
+        import_linker,
+        Vec::new(),
+        read_memory_syscall,
+        Some(100_000),
+        None,
+    );
+    assert!(wasmtime_worker.instantiate(&unlinked_module).is_err());
+    wasmtime_worker.execute("read_ok", &[], &mut []).unwrap();
+    assert_eq!(wasmtime_worker.data(), &[1, 2, 3, 4]);
 }

--- a/src/wasmtime/tests.rs
+++ b/src/wasmtime/tests.rs
@@ -470,3 +470,170 @@ fn test_wasmtime_executor_exports_follow_the_instance() {
         vec![1, 2, 3, 4]
     );
 }
+
+fn get_test_numeric_marshalling_module() -> (Module, Arc<ImportLinker>) {
+    let wasm_binary = wat::parse_str(
+        r#"
+            (module
+              (func $mix (import "host" "mix") (param i32 i64 f32 f64) (result i64))
+              (func (export "main") (result i64)
+                (i32.const -7)
+                (i64.const 0x1_0000_0000)
+                (f32.const 1.5)
+                (f64.const -2.25)
+                (call $mix)
+              )
+              (func (export "add") (param i32 i32) (result i32)
+                (i32.add (local.get 0) (local.get 1))
+              )
+              (func (export "pass_f64") (param f64) (result f64)
+                (local.get 0)
+              )
+              (func (export "widen") (param i32) (result i64)
+                (i64.extend_i32_s (local.get 0))
+              )
+            )
+            "#,
+    )
+    .unwrap();
+    let mut import_linker = ImportLinker::default();
+    import_linker.insert_function(
+        ImportName::new("host", "mix"),
+        0xcd,
+        SyscallFuelParams::default(),
+        &[
+            wasmparser::ValType::I32,
+            wasmparser::ValType::I64,
+            wasmparser::ValType::F32,
+            wasmparser::ValType::F64,
+        ],
+        &[wasmparser::ValType::I64],
+    );
+    let import_linker = Arc::new(import_linker);
+    let compilation_config = CompilationConfig::default().with_import_linker(import_linker.clone());
+    (
+        compile_wasmtime_module(compilation_config, wasm_binary).unwrap(),
+        import_linker,
+    )
+}
+
+/// Folds every parameter into one `i64` so the test can check each value arrived intact.
+fn mix_syscall(
+    _caller: &mut TypedCaller<'_, ()>,
+    sys_func_idx: u32,
+    params: &[Value],
+    result: &mut [Value],
+) -> Result<(), TrapCode> {
+    assert_eq!(sys_func_idx, 0xcd);
+    let [Value::I32(a), Value::I64(b), Value::F32(c), Value::F64(d)] = params else {
+        panic!("unexpected parameter types: {params:?}");
+    };
+    assert_eq!(c.to_bits(), 1.5f32.to_bits());
+    assert_eq!(d.to_bits(), (-2.25f64).to_bits());
+    result[0] = Value::I64(*a as i64 + *b + c.to_bits() as i64 + d.to_bits() as i64);
+    Ok(())
+}
+
+#[test]
+fn test_wasmtime_numeric_imports_round_trip_through_raw_slots() {
+    let (module, import_linker) = get_test_numeric_marshalling_module();
+    let mut wasmtime_worker =
+        WasmtimeExecutor::new(module, import_linker, (), mix_syscall, Some(100_000), None);
+
+    let mut result = [Value::I64(0)];
+    wasmtime_worker.execute("main", &[], &mut result).unwrap();
+    assert_eq!(
+        result[0],
+        Value::I64(-7 + 0x1_0000_0000 + 1.5f32.to_bits() as i64 + (-2.25f64).to_bits() as i64)
+    );
+}
+
+#[test]
+fn test_wasmtime_numeric_exports_marshal_params_and_results() {
+    let (module, import_linker) = get_test_numeric_marshalling_module();
+    let mut wasmtime_worker =
+        WasmtimeExecutor::new(module, import_linker, (), mix_syscall, Some(100_000), None);
+
+    let mut result = [Value::I32(0)];
+    wasmtime_worker
+        .execute("add", &[Value::I32(40), Value::I32(2)], &mut result)
+        .unwrap();
+    assert_eq!(result[0], Value::I32(42));
+
+    // Float values pass through untouched (float arithmetic itself is disabled by the engine).
+    let mut result = [Value::F64(crate::F64::from_bits(0))];
+    wasmtime_worker
+        .execute(
+            "pass_f64",
+            &[Value::F64(crate::F64::from_bits((-2.25f64).to_bits()))],
+            &mut result,
+        )
+        .unwrap();
+    assert_eq!(
+        result[0],
+        Value::F64(crate::F64::from_bits((-2.25f64).to_bits()))
+    );
+
+    let mut result = [Value::I64(0)];
+    wasmtime_worker
+        .execute("widen", &[Value::I32(-1)], &mut result)
+        .unwrap();
+    assert_eq!(result[0], Value::I64(-1));
+
+    // Mismatched arity or types are rejected before the call, as the checked path did.
+    let mut result = [Value::I32(0)];
+    assert_eq!(
+        wasmtime_worker
+            .execute("add", &[Value::I32(1)], &mut result)
+            .unwrap_err(),
+        TrapCode::IllegalOpcode
+    );
+    assert_eq!(
+        wasmtime_worker
+            .execute("add", &[Value::I64(1), Value::I32(1)], &mut result)
+            .unwrap_err(),
+        TrapCode::IllegalOpcode
+    );
+}
+
+#[test]
+fn test_wasmtime_raw_import_rejects_mistyped_syscall_results() {
+    let (module, import_linker) = get_test_numeric_marshalling_module();
+    let mut wasmtime_worker = WasmtimeExecutor::new(
+        module,
+        import_linker,
+        (),
+        |_caller, _sys_func_idx, _params, result| -> Result<(), TrapCode> {
+            result[0] = Value::I32(1);
+            Ok(())
+        },
+        Some(100_000),
+        None,
+    );
+
+    let mut result = [Value::I64(0)];
+    assert_eq!(
+        wasmtime_worker
+            .execute("main", &[], &mut result)
+            .unwrap_err(),
+        TrapCode::BadSignature
+    );
+}
+
+#[test]
+fn test_wasmtime_raw_import_halt_is_a_controlled_exit() {
+    let (module, import_linker) = get_test_numeric_marshalling_module();
+    let mut wasmtime_worker = WasmtimeExecutor::new(
+        module,
+        import_linker,
+        (),
+        |_caller, _sys_func_idx, _params, _result| -> Result<(), TrapCode> {
+            Err(TrapCode::ExecutionHalted)
+        },
+        Some(100_000),
+        None,
+    );
+
+    let mut result = [Value::I64(0)];
+    wasmtime_worker.execute("main", &[], &mut result).unwrap();
+}


### PR DESCRIPTION
## Summary

Profiling Fluentbase's EVM runtime under the wasmtime backend showed that a large share of every host call and every entry call was spent in the glue around the call rather than in the call itself:

- `get_export("memory")` on every guest memory read/write from a host function and on every memory access from the executor, plus `get_func(name)` on every entry call: string-keyed lookups in wasmtime's export table.
- `Store::get_fuel().is_ok()` on every fuel touch, which constructs an error value each time engine metering is off (the common case for self-metered runtimes).
- `func_new` imports boxing every parameter into a `Val` before the trampoline converts it again into a `Value`, and `Func::call` re-validating the signature and converting through `Val` on every entry call.

This PR removes those without changing the runtime contract:

- **Exports and fuel mode are resolved once.** The exported memory and the exported functions are cached per instantiation and the fuel mode per store. The cache is keyed on the `Instance` handle, so replacing the public `instance` field directly still resolves the right exports (Fluentbase does this today). `try_new` returns the instantiation error instead of panicking, and `instantiate` swaps a module in place.
- **Numeric signatures go through raw value slots.** Imports whose signature is numeric only are registered with `func_new_unchecked` and read their parameters straight from the `ValRaw` slots; numeric-only exports are called with `call_unchecked` against the type recorded when the export was cached. Reference-typed signatures keep the checked `Val` path. A syscall handler that produces a result of the wrong type now fails the call with `TrapCode::BadSignature` instead of a generic wasmtime error.

## Numbers

Fluentbase `e2e/benches/evmperf.rs` (native revm vs the rWasm-hosted EVM runtime), Apple Silicon, release, with this branch patched in against `rwasm 0.4.7`, two rounds back-to-back (µs per call):

| workload | before | after | change |
|---|---|---|---|
| ERC20 transfer (35k gas) | 11.4 / 11.9 | 9.2 / 9.1 | -21% |
| 2000 warm SLOADs | 1745 / 1765 | 1146 / 1101 | -36% (163 → 254 Mgas/s) |
| 2000 warm SSTOREs | 1731 / 1742 | 1099 / 1079 | -37% |
| arithmetic loop, no host calls | 364 / 365 | 367 / 364 | unchanged |
| keccak loop | 2751 / 2681 | 2668 / 2760 | unchanged |

One storage interruption round trip (yield out of wasmtime, host journal op, re-enter `main`) goes from ~0.87 µs to ~0.56 µs.

## Testing

- `cargo test` (all targets) and `cargo test --manifest-path e2e/Cargo.toml`
- `cargo clippy --all-targets --all-features`
- New unit tests: fuel accessors under engine metering and under the soft counter, export cache following `instantiate` and a direct `instance` swap, numeric import round trip (i32/i64/f32/f64), numeric export params/results with arity and type mismatches, mistyped syscall results rejected, `ExecutionHalted` from a raw import still a controlled exit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added faster handling for numeric WebAssembly function imports and exports.
  - Added fallible executor creation and support for re-instantiating modules while synchronizing exports and memory.
  - Improved fuel metering support when engine fuel metering is enabled or disabled.

- **Bug Fixes**
  - Ensured function and memory exports follow the active WebAssembly instance.
  - Improved validation and error handling for numeric argument and result mismatches.
  - Prevented halted calls from returning stale result values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->