### PR TITLE
fix(fuel): align the fuel policy with wasmtime-rwasm 45.0.0-rwasm.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,18 +234,16 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c4ebb31662e2051dcc49b7342d222405a99e951720756cc4b93315972abd67"
+version = "0.132.0"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dfc2ec96ec1c3a8a250602e936712e00a381df032f7a8ad175c8f768c03bb"
+version = "0.132.0"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cranelift-srcgen",
 ]
@@ -253,8 +251,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88217b08180882436d54c0133274885c590698ae854e352bede1cda041230800"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -263,8 +260,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bitset"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5c3cf7ba29fa56e56040848e34835d4e45988b2760ef212413409af95ffd8c1"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "serde",
  "serde_derive",
@@ -274,8 +270,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe1aac2efd4cba2047845fce38a68519935a30e20c8a6294ba7e2f448fe722d"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -302,8 +297,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0909eaf9d6f18f5bf802d50608cb4368ac340fbd03cc44f2888d1cfcc3faa64e"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -314,15 +308,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631c4e5db42e6a0f9e7a68f18f7faba3692862114870c7c598aee7e0e5677e59"
+version = "0.132.0"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 
 [[package]]
 name = "cranelift-control"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c6e92c825abfbb739a4beaa5db3988f98a96a68d6ea656f562098efc142976"
+version = "0.132.0"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "arbitrary",
 ]
@@ -330,8 +322,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a55309b47e6633ab05821304206cb1e92952e845b1224985562bb7ac1e92323"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -342,8 +333,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064d2d3533d9608f1cf44c8899cf2f7f33feb70300b0fb83e687b0d9e7b91147"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -354,14 +344,12 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac4e0bc095b2dab2212d1e99d7a74b62afc1485db023f1c0cb34a68758f7bd1"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 
 [[package]]
 name = "cranelift-native"
 version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a40053f5cb925451dd1d57393d14ad3145c8e0786701c27b5415ebb9a3ba4f"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -370,9 +358,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.132.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdbadda21e49798825a1ec795dab30bcb03235891f662b5ccf23fa45b39682f"
+version = "0.132.0"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 
 [[package]]
 name = "crc32fast"
@@ -1101,8 +1088,7 @@ dependencies = [
 [[package]]
 name = "pulley-interpreter"
 version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9204ad9435f2a6fe3bd13bba52389fb8488fa20ba497e35c5d2db638166019d"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -1113,8 +1099,7 @@ dependencies = [
 [[package]]
 name = "pulley-macros"
 version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53009b033747e0d79a76549a744da58e84c9da8076492c7e6d491fdc6cc41b95"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1872,41 +1857,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-environ"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7da3dcce82a7e784121c19c8c9c5f69a743088264ff5212033e4a1f1b9dfaaf"
-dependencies = [
- "anyhow",
- "cpp_demangle",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-entity",
- "gimli",
- "hashbrown 0.17.1",
- "indexmap",
- "log",
- "object",
- "postcard",
- "rustc-demangle",
- "semver",
- "serde",
- "serde_derive",
- "sha2",
- "smallvec",
- "target-lexicon",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
- "wasmprinter",
- "wasmtime-internal-component-util",
- "wasmtime-internal-core",
-]
-
-[[package]]
 name = "wasmtime-environ-rwasm"
-version = "45.0.0-rwasm.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73117df680a463ba611cc40536d40cac3d0099816f6f9ee0c4847ad1ece8b"
+version = "45.0.0-rwasm.2"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -1937,8 +1890,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-cache"
 version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef87f84d976e2f98a541eaf5837df0424e2039837fc20bd6cd4b4b5a322939c0"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "base64",
  "directories-next",
@@ -1949,7 +1901,7 @@ dependencies = [
  "serde_derive",
  "sha2",
  "toml",
- "wasmtime-environ",
+ "wasmtime-environ-rwasm",
  "windows-sys",
  "zstd",
 ]
@@ -1957,8 +1909,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-component-macro"
 version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86991f201391afc1504e4fc363dc29b66f92af0287b4ac2efc3c0b0c19435eeb"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1972,14 +1923,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-component-util"
 version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47fda091250d7ab839ea51e4d98190b6eee37e9de4ab2462e8fe8465369c1986"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 
 [[package]]
 name = "wasmtime-internal-core"
 version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bdae4b55b15a23d774b15f6e7cd90ae0d0aa17c47c12b4db098b3dd11ba9d58"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -1988,36 +1937,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-cranelift"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5773b36b87566239b020f1d01aa753a35626df85030485e40e36fc42a97acf4f"
-dependencies = [
- "cfg-if",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
- "gimli",
- "itertools 0.14.0",
- "log",
- "object",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
-]
-
-[[package]]
 name = "wasmtime-internal-cranelift-rwasm"
-version = "45.0.0-rwasm.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e606f841cc3e88b56bf671f334e69776e144b0cd7da21f1125f4c558706ff9"
+version = "45.0.0-rwasm.2"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -2044,14 +1966,13 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-fiber"
 version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402cce4bba4c8c92a6fbaff39a6b23f8aa626d64b218ecf6dd3eeee8705cf096"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "rustix",
- "wasmtime-environ",
+ "wasmtime-environ-rwasm",
  "wasmtime-internal-versioned-export-macros",
  "windows-sys",
 ]
@@ -2059,8 +1980,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-debug"
 version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b426a5d0ec9c11a1a4525ed4e973b7caf40223b6d392588bb9f6468e4ae9d29"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cc",
  "object",
@@ -2071,8 +1991,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
 version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a312ba8bb77955dcd44294a223e7f124c3071ff966583d385d3f6a4639c62e3"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2083,21 +2002,19 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-unwinder"
 version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a62ad422ee3cbf1e87c2242dc0717a01c7a5878fbc3a68abc4b4d2fff3e85e1"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "log",
  "object",
- "wasmtime-environ",
+ "wasmtime-environ-rwasm",
 ]
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
 version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c660c5b091648cffdd84a34dc24ffcdb9d027f9048fe7bd5e01896adbd0935f"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2107,8 +2024,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-winch"
 version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2aceb92b48b6e3a5cc2a05ab7a2dcb565eaf86fb870d04664b7f12cf9bba39a"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cranelift-codegen",
  "gimli",
@@ -2116,16 +2032,15 @@ dependencies = [
  "object",
  "target-lexicon",
  "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
+ "wasmtime-environ-rwasm",
+ "wasmtime-internal-cranelift-rwasm",
  "winch-codegen",
 ]
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
 version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce382df367ad2a2d48e139b191dbca3329f7232a43057dc9efc889dac54f1b0b"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2136,9 +2051,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-rwasm"
-version = "45.0.0-rwasm.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "484c5fcd5ebb49c4e1f823e685e2d33093c9ef7adeb860f976780a88d83217ec"
+version = "45.0.0-rwasm.2"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -2244,8 +2158,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winch-codegen"
 version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3128bd53313b132e8737d7d318edbc438bab1abe525ac037bbf9857839e717e2"
+source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
@@ -2255,9 +2168,9 @@ dependencies = [
  "target-lexicon",
  "thiserror 2.0.18",
  "wasmparser 0.248.0",
- "wasmtime-environ",
+ "wasmtime-environ-rwasm",
  "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
+ "wasmtime-internal-cranelift-rwasm",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,16 +234,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.132.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d521bdbc6098937af83ef4ab6d5c07398126bc71878f7ef4ea9499977978ef5"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.132.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dde0b83164d4a497860af4236271178bc640512b067101e0853e4f74eaa4df5"
 dependencies = [
  "cranelift-srcgen",
 ]
@@ -251,7 +253,8 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.132.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88217b08180882436d54c0133274885c590698ae854e352bede1cda041230800"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -260,7 +263,8 @@ dependencies = [
 [[package]]
 name = "cranelift-bitset"
 version = "0.132.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c3cf7ba29fa56e56040848e34835d4e45988b2760ef212413409af95ffd8c1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -270,7 +274,8 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.132.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe1aac2efd4cba2047845fce38a68519935a30e20c8a6294ba7e2f448fe722d"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -297,7 +302,8 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.132.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0909eaf9d6f18f5bf802d50608cb4368ac340fbd03cc44f2888d1cfcc3faa64e"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -308,13 +314,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.132.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07f156b90efc94371ddb3536f76e4ab671ad2e093bfa5511e10198cadbb0c47"
 
 [[package]]
 name = "cranelift-control"
-version = "0.132.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a76fd9dd37dcbc3d2d2e00abe3281a7e88adc035fba3b8114cc69981576ec"
 dependencies = [
  "arbitrary",
 ]
@@ -322,7 +330,8 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.132.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a55309b47e6633ab05821304206cb1e92952e845b1224985562bb7ac1e92323"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -333,7 +342,8 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.132.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064d2d3533d9608f1cf44c8899cf2f7f33feb70300b0fb83e687b0d9e7b91147"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -344,12 +354,14 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.132.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac4e0bc095b2dab2212d1e99d7a74b62afc1485db023f1c0cb34a68758f7bd1"
 
 [[package]]
 name = "cranelift-native"
 version = "0.132.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a40053f5cb925451dd1d57393d14ad3145c8e0786701c27b5415ebb9a3ba4f"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -358,8 +370,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.132.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004643f39a7bec553de5263d650db30e5b9caec1d5cbe065fd732b7ec9ae40d0"
 
 [[package]]
 name = "crc32fast"
@@ -1088,7 +1101,8 @@ dependencies = [
 [[package]]
 name = "pulley-interpreter"
 version = "45.0.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9204ad9435f2a6fe3bd13bba52389fb8488fa20ba497e35c5d2db638166019d"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -1099,7 +1113,8 @@ dependencies = [
 [[package]]
 name = "pulley-macros"
 version = "45.0.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53009b033747e0d79a76549a744da58e84c9da8076492c7e6d491fdc6cc41b95"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1857,9 +1872,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-environ"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7da3dcce82a7e784121c19c8c9c5f69a743088264ff5212033e4a1f1b9dfaaf"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "log",
+ "object",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+]
+
+[[package]]
 name = "wasmtime-environ-rwasm"
 version = "45.0.0-rwasm.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54fdc11189069a3102450edb72db65065b9c00942b06118fb938ef68fe18d942"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -1890,7 +1937,8 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-cache"
 version = "45.0.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef87f84d976e2f98a541eaf5837df0424e2039837fc20bd6cd4b4b5a322939c0"
 dependencies = [
  "base64",
  "directories-next",
@@ -1901,7 +1949,7 @@ dependencies = [
  "serde_derive",
  "sha2",
  "toml",
- "wasmtime-environ-rwasm",
+ "wasmtime-environ",
  "windows-sys",
  "zstd",
 ]
@@ -1909,7 +1957,8 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-component-macro"
 version = "45.0.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86991f201391afc1504e4fc363dc29b66f92af0287b4ac2efc3c0b0c19435eeb"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1923,12 +1972,14 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-component-util"
 version = "45.0.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47fda091250d7ab839ea51e4d98190b6eee37e9de4ab2462e8fe8465369c1986"
 
 [[package]]
 name = "wasmtime-internal-core"
 version = "45.0.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bdae4b55b15a23d774b15f6e7cd90ae0d0aa17c47c12b4db098b3dd11ba9d58"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -1937,9 +1988,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-internal-cranelift"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773b36b87566239b020f1d01aa753a35626df85030485e40e36fc42a97acf4f"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools 0.14.0",
+ "log",
+ "object",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
 name = "wasmtime-internal-cranelift-rwasm"
 version = "45.0.0-rwasm.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84f88615a7fe28d63d70bf714cb99a6454c3781870b4bb594e07e0aaea4a5554"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -1966,13 +2044,14 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-fiber"
 version = "45.0.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402cce4bba4c8c92a6fbaff39a6b23f8aa626d64b218ecf6dd3eeee8705cf096"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "rustix",
- "wasmtime-environ-rwasm",
+ "wasmtime-environ",
  "wasmtime-internal-versioned-export-macros",
  "windows-sys",
 ]
@@ -1980,7 +2059,8 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-debug"
 version = "45.0.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b426a5d0ec9c11a1a4525ed4e973b7caf40223b6d392588bb9f6468e4ae9d29"
 dependencies = [
  "cc",
  "object",
@@ -1991,7 +2071,8 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
 version = "45.0.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a312ba8bb77955dcd44294a223e7f124c3071ff966583d385d3f6a4639c62e3"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2002,19 +2083,21 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-unwinder"
 version = "45.0.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a62ad422ee3cbf1e87c2242dc0717a01c7a5878fbc3a68abc4b4d2fff3e85e1"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "log",
  "object",
- "wasmtime-environ-rwasm",
+ "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
 version = "45.0.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c660c5b091648cffdd84a34dc24ffcdb9d027f9048fe7bd5e01896adbd0935f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2024,7 +2107,8 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-winch"
 version = "45.0.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2aceb92b48b6e3a5cc2a05ab7a2dcb565eaf86fb870d04664b7f12cf9bba39a"
 dependencies = [
  "cranelift-codegen",
  "gimli",
@@ -2032,15 +2116,16 @@ dependencies = [
  "object",
  "target-lexicon",
  "wasmparser 0.248.0",
- "wasmtime-environ-rwasm",
- "wasmtime-internal-cranelift-rwasm",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
  "winch-codegen",
 ]
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
 version = "45.0.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce382df367ad2a2d48e139b191dbca3329f7232a43057dc9efc889dac54f1b0b"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2052,7 +2137,8 @@ dependencies = [
 [[package]]
 name = "wasmtime-rwasm"
 version = "45.0.0-rwasm.2"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7190b4e1967b61301246afa4890bbb5fa2b114ad0e4ebb84cbd451de3670e2a"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -2158,7 +2244,8 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winch-codegen"
 version = "45.0.0"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime.git?tag=v45.0.0-rwasm.2#2bfbe022649713ae1898fa8b18f5797998499c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3128bd53313b132e8737d7d318edbc438bab1abe525ac037bbf9857839e717e2"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
@@ -2168,9 +2255,9 @@ dependencies = [
  "target-lexicon",
  "thiserror 2.0.18",
  "wasmparser 0.248.0",
- "wasmtime-environ-rwasm",
+ "wasmtime-environ",
  "wasmtime-internal-core",
- "wasmtime-internal-cranelift-rwasm",
+ "wasmtime-internal-cranelift",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ spin = "0.12.2"
 serde = { version = "1.0.219", features = ["derive", "rc"], optional = true }
 
 # wasmtime
-wasmtime = { version = "45.0.0-rwasm.1", package = "wasmtime-rwasm", optional = true, features = ["cache"] }
+wasmtime = { version = "45.0.0-rwasm.2", package = "wasmtime-rwasm", optional = true, features = ["cache"] }
 directories = { version = "6.0.0", optional = true }
 lru = { version = "0.16.3", optional = true }
 
@@ -79,3 +79,9 @@ full-wasm-mode = ["wasmtime?/full-wasm-mode"]
 [[bench]]
 name = "bench"
 harness = false
+
+# TEMPORARY: `wasmtime-rwasm` 45.0.0-rwasm.2 (region-based fuel metering aligned with the rwasm VM,
+# fluentlabs-xyz/wasmtime#11) is tagged but not yet on crates.io, so it is taken from the fork's
+# release tag. Remove this section once the crate is published.
+[patch.crates-io]
+wasmtime-rwasm = { git = "https://github.com/fluentlabs-xyz/wasmtime.git", tag = "v45.0.0-rwasm.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,9 +79,3 @@ full-wasm-mode = ["wasmtime?/full-wasm-mode"]
 [[bench]]
 name = "bench"
 harness = false
-
-# TEMPORARY: `wasmtime-rwasm` 45.0.0-rwasm.2 (region-based fuel metering aligned with the rwasm VM,
-# fluentlabs-xyz/wasmtime#11) is tagged but not yet on crates.io, so it is taken from the fork's
-# release tag. Remove this section once the crate is published.
-[patch.crates-io]
-wasmtime-rwasm = { git = "https://github.com/fluentlabs-xyz/wasmtime.git", tag = "v45.0.0-rwasm.2" }

--- a/docs/vm-and-fuel.md
+++ b/docs/vm-and-fuel.md
@@ -37,6 +37,28 @@ Fuel is part of runtime policy and can be consumed by:
 - explicit fuel opcodes (`ConsumeFuel`, `ConsumeFuelStack`)
 - host/syscall operations through runtime wrappers/policies
 
+### Engine alignment
+
+The rwasm VM and the Wasmtime strategy (`wasmtime-rwasm`) implement one fuel policy; the
+per-operator schedule lives in the shared `rwasm-fuel-policy` crate. Both engines also agree on
+*when* fuel is charged and checked:
+
+- Metering is eager and region based. Each straight-line region (function entry, loop header,
+  `if` arm, `else` arm, the code after any `end`, the fall-through after `br_if`) is charged in
+  full before its first instruction runs. rwasm does this with one `ConsumeFuel` per region;
+  Wasmtime emits the same charge in native code. A trap therefore leaves the same counter behind
+  on both engines.
+- A charge that exceeds the remaining fuel is never applied: execution traps with `OutOfFuel` and
+  the remaining fuel stays what it was before the region.
+- `fuel_limit: None` is unbounded on both engines and `remaining_fuel()` returns `None`.
+- `LinearFuelParams::param_index` and `QuadraticFuelParams::local_depth` address the imported
+  function's parameters by position counted from the last parameter, independent of the stack
+  slots those parameters occupy.
+
+Only `consume_fuel_for_bulk_ops` and `consume_fuel_for_params_and_locals` remain rwasm-only; use
+`CompilationConfig::default_strategy_compatible` for modules that may run on either engine.
+`tests/fuel_alignment.rs` pins these invariants differentially.
+
 ## Traps and errors
 
 Typical trap categories include:

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -11,3 +11,9 @@ wast = "=64.0"
 [features]
 default = ["rwasm/full-wasm-mode"]
 debug-print = ["rwasm/debug-print"]
+
+# TEMPORARY: `wasmtime-rwasm` 45.0.0-rwasm.2 (region-based fuel metering aligned with the rwasm VM,
+# fluentlabs-xyz/wasmtime#11) is tagged but not yet on crates.io, so it is taken from the fork's
+# release tag. Remove this section once the crate is published.
+[patch.crates-io]
+wasmtime-rwasm = { git = "https://github.com/fluentlabs-xyz/wasmtime.git", tag = "v45.0.0-rwasm.2" }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -11,9 +11,3 @@ wast = "=64.0"
 [features]
 default = ["rwasm/full-wasm-mode"]
 debug-print = ["rwasm/debug-print"]
-
-# TEMPORARY: `wasmtime-rwasm` 45.0.0-rwasm.2 (region-based fuel metering aligned with the rwasm VM,
-# fluentlabs-xyz/wasmtime#11) is tagged but not yet on crates.io, so it is taken from the fork's
-# release tag. Remove this section once the crate is published.
-[patch.crates-io]
-wasmtime-rwasm = { git = "https://github.com/fluentlabs-xyz/wasmtime.git", tag = "v45.0.0-rwasm.2" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -43,9 +43,3 @@ default = ["disable-signals"]
 disable-signals = []
 
 [workspace]
-
-# TEMPORARY: `wasmtime-rwasm` 45.0.0-rwasm.2 (region-based fuel metering aligned with the rwasm VM,
-# fluentlabs-xyz/wasmtime#11) is tagged but not yet on crates.io, so it is taken from the fork's
-# release tag. Remove this section once the crate is published.
-[patch.crates-io]
-wasmtime-rwasm = { git = "https://github.com/fluentlabs-xyz/wasmtime.git", tag = "v45.0.0-rwasm.2" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ arbitrary = "1.4.2"
 # Needed to map export names -> indices for snapshotting globals/tables/memory.
 # Use the same package/version as `rwasm` itself to avoid version skew.
 wasmparser = { version = "0.100.1", package = "wasmparser-nostd", default-features = false }
-wasmtime = { package = "wasmtime-rwasm", version = "45.0.0-rwasm.1" }
+wasmtime = { package = "wasmtime-rwasm", version = "45.0.0-rwasm.2" }
 wasm-smith = "0.258.0"
 hex = "0.4.3"
 log = "0.4.26"
@@ -43,3 +43,9 @@ default = ["disable-signals"]
 disable-signals = []
 
 [workspace]
+
+# TEMPORARY: `wasmtime-rwasm` 45.0.0-rwasm.2 (region-based fuel metering aligned with the rwasm VM,
+# fluentlabs-xyz/wasmtime#11) is tagged but not yet on crates.io, so it is taken from the fork's
+# release tag. Remove this section once the crate is published.
+[patch.crates-io]
+wasmtime-rwasm = { git = "https://github.com/fluentlabs-xyz/wasmtime.git", tag = "v45.0.0-rwasm.2" }

--- a/src/compiler/block_fuel.rs
+++ b/src/compiler/block_fuel.rs
@@ -1,22 +1,50 @@
 use crate::{
-    instruction_set_internal, BranchOffset, InstructionSet, LocalDepth, TrapCode, UntypedValue,
+    instruction_set_internal, BranchOffset, CompilationError, InstructionSet, LocalDepth, TrapCode,
+    UntypedValue,
 };
 use rwasm_fuel_policy::{SyscallFuelParams, FUEL_MAX_LINEAR_X, FUEL_MAX_QUADRATIC_X};
+use wasmparser::ValType;
+
+/// Converts the parameter position a syscall fuel policy refers to into the stack depth
+/// `LocalGet` expects inside the import trampoline.
+///
+/// `LinearFuelParams::param_index` and `QuadraticFuelParams::local_depth` count the imported
+/// function's parameters from the last one (`1` is the last parameter). That is what the Wasmtime
+/// engine reads with `peekn`, where every parameter is one value. On the rwasm stack an `i64` or
+/// `f64` parameter occupies two 32-bit slots, so the depth has to skip two slots for each such
+/// parameter above the metered one. The metered parameter itself is a byte length and therefore
+/// a single `i32` slot.
+fn param_slot_depth(params: &[ValType], param_index: u32) -> Result<LocalDepth, CompilationError> {
+    let param_index = usize::try_from(param_index)
+        .ok()
+        .filter(|index| (1..=params.len()).contains(index))
+        .ok_or(CompilationError::InvalidSyscallFuelParam)?;
+    let slots_above = params[params.len() - param_index + 1..]
+        .iter()
+        .map(|ty| match ty {
+            ValType::I64 | ValType::F64 => 2,
+            _ => 1,
+        })
+        .sum::<u32>();
+    Ok(slots_above + 1)
+}
 
 pub(crate) fn compile_block_params(
     isa: &mut InstructionSet,
     syscall_fuel_param: SyscallFuelParams,
-) {
+    params: &[ValType],
+) -> Result<(), CompilationError> {
     match syscall_fuel_param {
         SyscallFuelParams::None => {}
         SyscallFuelParams::Const(base) => isa.op_consume_fuel(base as u32),
         SyscallFuelParams::LinearFuel(fuel_params) => {
-            isa.op_local_get(LocalDepth::from(fuel_params.param_index));
+            let depth = param_slot_depth(params, fuel_params.param_index)?;
+            isa.op_local_get(depth);
             isa.op_i32_const(UntypedValue::from(FUEL_MAX_LINEAR_X));
             isa.op_i32_gt_u();
             isa.op_br_if_eqz(BranchOffset::from(2));
             isa.op_trap(TrapCode::IntegerOverflow);
-            isa.op_local_get(LocalDepth::from(fuel_params.param_index));
+            isa.op_local_get(depth);
             isa.op_i32_const(UntypedValue::from(31));
             isa.op_i32_add();
             isa.op_i32_const(UntypedValue::from(32));
@@ -30,16 +58,17 @@ pub(crate) fn compile_block_params(
             isa.op_consume_fuel_stack()
         }
         SyscallFuelParams::QuadraticFuel(fuel_params) => {
+            let depth = param_slot_depth(params, fuel_params.local_depth)?;
             instruction_set_internal! {
                 isa,
                  // Runtime overflow check
-                LocalGet(fuel_params.local_depth)
+                LocalGet(depth)
                 I32Const(FUEL_MAX_QUADRATIC_X)
                 I32GtU
                 BrIfEqz(2)
                 Trap(TrapCode::IntegerOverflow)
                 // Linear part: word_cost × words
-                LocalGet(fuel_params.local_depth)
+                LocalGet(depth)
                 I32Const(31)
                 I32Add
                 I32Const(32)
@@ -47,12 +76,12 @@ pub(crate) fn compile_block_params(
                 I32Const(fuel_params.word_cost)
                 I32Mul
                 // Quadratic part: words² / divisor
-                LocalGet(fuel_params.local_depth + 1) // linear part left words on stack
+                LocalGet(depth + 1) // linear part left words on stack
                 I32Const(31)
                 I32Add
                 I32Const(32)
                 I32DivU
-                LocalGet(fuel_params.local_depth + 2) // linear and first words on stack
+                LocalGet(depth + 2) // linear and first words on stack
                 I32Const(31)
                 I32Add
                 I32Const(32)
@@ -68,5 +97,30 @@ pub(crate) fn compile_block_params(
                 ConsumeFuelStack
             }
         }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn param_slot_depth_counts_two_slots_per_i64_above_the_metered_param() {
+        use ValType::*;
+        assert_eq!(param_slot_depth(&[I32], 1).unwrap(), 1);
+        assert_eq!(param_slot_depth(&[I32, I32, I32], 1).unwrap(), 1);
+        assert_eq!(param_slot_depth(&[I32, I32, I32], 3).unwrap(), 3);
+        assert_eq!(param_slot_depth(&[I32, I64], 2).unwrap(), 3);
+        assert_eq!(param_slot_depth(&[I64, I32], 1).unwrap(), 1);
+        assert_eq!(param_slot_depth(&[I32, F64, I64, I32], 4).unwrap(), 6);
+    }
+
+    #[test]
+    fn param_slot_depth_rejects_out_of_range_positions() {
+        use ValType::*;
+        assert!(param_slot_depth(&[I32, I32], 0).is_err());
+        assert!(param_slot_depth(&[I32, I32], 3).is_err());
+        assert!(param_slot_depth(&[], 1).is_err());
     }
 }

--- a/src/compiler/error.rs
+++ b/src/compiler/error.rs
@@ -5,6 +5,8 @@ use wasmparser::BinaryReaderError;
 pub enum CompilationError {
     BranchOffsetOutOfBounds,
     BlockFuelOutOfBounds,
+    /// A syscall fuel policy points at a parameter the imported function does not have.
+    InvalidSyscallFuelParam,
     NotSupportedExtension,
     DropKeepOutOfBounds,
     BranchTableTargetsOutOfBounds,
@@ -40,6 +42,9 @@ impl core::fmt::Display for CompilationError {
         match self {
             CompilationError::BranchOffsetOutOfBounds => write!(f, "branch offset out of bounds"),
             CompilationError::BlockFuelOutOfBounds => write!(f, "block fuel out of bounds"),
+            CompilationError::InvalidSyscallFuelParam => {
+                write!(f, "syscall fuel parameter index is out of range")
+            }
             CompilationError::NotSupportedExtension => write!(f, "not supported extension"),
             CompilationError::DropKeepOutOfBounds => write!(f, "drop keep out of bounds"),
             CompilationError::BranchTableTargetsOutOfBounds => {

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -536,7 +536,8 @@ impl ModuleParser {
                 compile_block_params(
                     &mut translator.alloc.instruction_set,
                     import_linker_entity.syscall_fuel_param,
-                )
+                    import_linker_entity.params,
+                )?;
             }
 
             translator

--- a/src/compiler/translator.rs
+++ b/src/compiler/translator.rs
@@ -17,7 +17,8 @@ use crate::{
     },
     AddressOffset, BranchOffset, BranchTableTargets, ConstructorParams, DataSegmentIdx,
     ElementSegmentIdx, FuncIdx, FuncTypeIdx, GlobalVariable, InstrLoc, InstructionSet, LabelRef,
-    Opcode, TableIdx, DEFAULT_MEMORY_INDEX, N_MAX_TABLE_SIZE, SNIPPET_FUNC_IDX_UNRESOLVED,
+    Opcode, TableIdx, TrapCode, DEFAULT_MEMORY_INDEX, N_MAX_TABLE_SIZE,
+    SNIPPET_FUNC_IDX_UNRESOLVED,
 };
 use alloc::{boxed::Box, vec::Vec};
 use bitvec::macros::internal::funty::Fundamental;
@@ -547,6 +548,23 @@ impl InstructionTranslator {
             .len()
             .checked_sub(1)
             .expect("the control flow frame stack must not be empty") as u32
+    }
+
+    /// Ends the current code path when the operator just emitted lowered to an unconditional
+    /// `Trap(IllegalOpcode)`.
+    ///
+    /// Without the `fpu` feature every float operator compiles to that trap (see
+    /// `impl_fpu_opcode!`). Nothing after it can execute, so translating the rest of the block
+    /// would only grow the bytecode and, with metering on, charge the dead tail to the region
+    /// that traps. Wasmtime marks the same operators unreachable, and both engines must charge
+    /// the same fuel up to the trap.
+    fn end_path_if_illegal_opcode(&mut self) {
+        if matches!(
+            self.alloc.instruction_set.instr.last(),
+            Some(Opcode::Trap(TrapCode::IllegalOpcode))
+        ) {
+            self.reachable = false;
+        }
     }
 
     /// Translates into `rwasm` bytecode if the current code path is reachable.
@@ -3916,6 +3934,7 @@ impl InstructionTranslator {
             builder.alloc.stack_types.push(loaded_type);
             let offset = AddressOffset::from(memarg.offset as u32);
             emitter(&mut builder.alloc.instruction_set, offset);
+            builder.end_path_if_illegal_opcode();
             Ok(())
         })
     }
@@ -3940,6 +3959,7 @@ impl InstructionTranslator {
             builder.stack_height.pop_n(max_stack_height);
             let offset = AddressOffset::from(memarg.offset as u32);
             emitter(&mut builder.alloc.instruction_set, offset);
+            builder.end_path_if_illegal_opcode();
             Ok(())
         })
     }
@@ -3965,6 +3985,7 @@ impl InstructionTranslator {
                 builder.stack_height.pop_n(max_stack_height);
             }
             emitter(&mut builder.alloc.instruction_set);
+            builder.end_path_if_illegal_opcode();
             Ok(())
         })
     }
@@ -4011,6 +4032,7 @@ impl InstructionTranslator {
             }
             // emit an instruction
             emitter(&mut builder.alloc.instruction_set);
+            builder.end_path_if_illegal_opcode();
             Ok(())
         })
     }
@@ -4107,6 +4129,7 @@ impl InstructionTranslator {
             }
             // emit an opcode
             emitter(&mut builder.alloc.instruction_set);
+            builder.end_path_if_illegal_opcode();
             Ok(())
         })
     }
@@ -4128,6 +4151,7 @@ impl InstructionTranslator {
             builder.stack_height.pop_n(max_stack_height);
             // emit instruction
             emitter(&mut builder.alloc.instruction_set);
+            builder.end_path_if_illegal_opcode();
             Ok(())
         })
     }
@@ -4149,6 +4173,7 @@ impl InstructionTranslator {
             builder.stack_height.pop_n(max_stack_height);
             // emit opcode
             emitter(&mut builder.alloc.instruction_set);
+            builder.end_path_if_illegal_opcode();
             Ok(())
         })
     }

--- a/src/wasmtime/context.rs
+++ b/src/wasmtime/context.rs
@@ -30,6 +30,9 @@ pub(crate) fn remaining_fuel<T: 'static>(
     ctx: impl AsContext<Data = WrappedContext<T>>,
 ) -> Option<u64> {
     let ctx = ctx.as_context();
+    if ctx.data().fuel_unbounded {
+        return None;
+    }
     if ctx.data().fuel_enabled {
         ctx.get_fuel().ok()
     } else {
@@ -45,6 +48,7 @@ pub(crate) fn reset_fuel<T: 'static>(
     let mut ctx = ctx.as_context_mut();
     if ctx.data().fuel_enabled {
         ctx.set_fuel(new_fuel_limit).expect(ENGINE_FUEL_EXPECTED);
+        ctx.data_mut().fuel_unbounded = false;
     } else {
         ctx.data_mut().fuel = Some(new_fuel_limit);
     }
@@ -60,6 +64,10 @@ pub struct WrappedContext<T: 'static> {
     /// error value each time metering is off, which is the common case for self-metered
     /// runtimes.
     pub(crate) fuel_enabled: bool,
+    /// Set when the executor was created without a fuel limit while the engine meters fuel:
+    /// the store then holds `u64::MAX` and reports no remaining fuel, like an rwasm store
+    /// without a limit.
+    pub(crate) fuel_unbounded: bool,
     /// The instance's exported memory, resolved once per instantiation so host calls don't
     /// look it up by name.
     pub(crate) memory: Option<wasmtime::Memory>,

--- a/src/wasmtime/instance.rs
+++ b/src/wasmtime/instance.rs
@@ -151,6 +151,7 @@ impl<T: 'static> WasmtimeExecutor<T> {
             syscall_handler,
             fuel: None,
             fuel_enabled: false,
+            fuel_unbounded: false,
             memory: None,
             resource_limiter,
             data,
@@ -159,12 +160,14 @@ impl<T: 'static> WasmtimeExecutor<T> {
         store.limiter(|ctx| &mut ctx.resource_limiter);
         let fuel_enabled = store.get_fuel().is_ok();
         store.data_mut().fuel_enabled = fuel_enabled;
-        if let Some(fuel) = fuel_limit {
-            if fuel_enabled {
-                store.set_fuel(fuel)?;
-            } else {
-                store.data_mut().fuel = Some(fuel);
-            }
+        if fuel_enabled {
+            // A Wasmtime store starts with zero fuel, so leaving it untouched for `None` would
+            // trap on the first function entry where the rwasm VM runs unbounded. Fill the store
+            // and flag it unbounded instead.
+            store.set_fuel(fuel_limit.unwrap_or(u64::MAX))?;
+            store.data_mut().fuel_unbounded = fuel_limit.is_none();
+        } else {
+            store.data_mut().fuel = fuel_limit;
         }
         #[allow(unused_mut)]
         let mut linker = wasmtime_import_linker(module.engine(), &import_linker);

--- a/tests/fuel_alignment.rs
+++ b/tests/fuel_alignment.rs
@@ -1,0 +1,815 @@
+//! Differential fuel tests: the same wasm module must burn the same fuel, stop at the same point
+//! and report the same remaining fuel on the rwasm VM and on Wasmtime.
+//!
+//! Every test compiles one module with [`CompilationConfig::default_strategy_compatible`] and
+//! runs it through [`for_each_strategy`], which yields the rwasm outcome first and the Wasmtime
+//! outcome second. The tests pin the invariants both engines implement:
+//!
+//! - Metering is eager and region based. A straight-line region (function entry, loop header,
+//!   `if` arm, `else` arm, the code after any `end`, the fall-through after `br_if`) is charged
+//!   in full before its first instruction runs, so a trap inside a region, or in a callee, leaves
+//!   the same counter on both engines.
+//! - A charge that does not fit in the remaining fuel is never applied: execution traps with
+//!   `OutOfFuel` and the remaining fuel stays what it was before the region.
+//! - `fuel_limit: None` is unbounded and reports no remaining fuel.
+//! - Syscall fuel parameters are addressed by parameter position counted from the last
+//!   parameter, regardless of how many stack slots the parameters above it occupy.
+//! - Disabled float operators trap after charging the code up to and including the operator.
+//!
+//! The absolute numbers asserted below double as a record of the shared schedule.
+
+use rwasm::{
+    for_each_strategy, CompilationConfig, ImportLinker, ImportName, StoreTr, SyscallHandler,
+    TrapCode, TypedCaller, Value,
+};
+use rwasm_fuel_policy::{LinearFuelParams, QuadraticFuelParams, SyscallFuelParams};
+use std::sync::Arc;
+use wasmparser::ValType;
+
+/// Everything observable about one execution that the two engines must agree on.
+#[derive(Debug, Clone, PartialEq)]
+struct Outcome {
+    trap: Option<TrapCode>,
+    remaining_fuel: Option<u64>,
+    result: Vec<Value>,
+    /// First `memory_prefix` bytes of the exported memory, empty when not requested.
+    memory: Vec<u8>,
+}
+
+struct Run<'a> {
+    wat: &'a str,
+    import_linker: Arc<ImportLinker>,
+    syscall_handler: SyscallHandler<()>,
+    fuel_limit: Option<u64>,
+    params: &'a [Value],
+    /// Typed template for the result buffer; rwasm sizes the returned stack slots from it.
+    results: &'a [Value],
+    /// How many leading bytes of the exported `memory` to capture (0 = module has no memory).
+    memory_prefix: usize,
+}
+
+impl<'a> Run<'a> {
+    fn plain(wat: &'a str, fuel_limit: Option<u64>) -> Self {
+        Self {
+            wat,
+            import_linker: Arc::new(ImportLinker::default()),
+            syscall_handler: rwasm::always_failing_syscall_handler,
+            fuel_limit,
+            params: &[],
+            results: &[],
+            memory_prefix: 0,
+        }
+    }
+
+    fn config(&self) -> CompilationConfig {
+        CompilationConfig::default_strategy_compatible()
+            .with_entrypoint_name("main".into())
+            .with_allow_malformed_entrypoint_func_type(true)
+            .with_import_linker(self.import_linker.clone())
+            .with_builtins_consume_fuel(true)
+    }
+
+    /// Returns `(rwasm, wasmtime)` outcomes.
+    fn execute(&self) -> (Outcome, Outcome) {
+        let wasm_binary = wat::parse_str(self.wat).unwrap();
+        let outcomes = for_each_strategy(
+            |strategy| {
+                let mut executor = strategy.create_executor(
+                    self.import_linker.clone(),
+                    (),
+                    self.syscall_handler,
+                    self.fuel_limit,
+                    None,
+                )?;
+                let mut result = self.results.to_vec();
+                let trap = executor.execute("main", self.params, &mut result).err();
+                let memory = if self.memory_prefix > 0 {
+                    executor.snapshot_memory()?[..self.memory_prefix].to_vec()
+                } else {
+                    Vec::new()
+                };
+                Ok(Outcome {
+                    trap,
+                    remaining_fuel: executor.remaining_fuel(),
+                    result,
+                    memory,
+                })
+            },
+            self.config(),
+            &wasm_binary,
+        )
+        .unwrap();
+        assert_eq!(
+            outcomes.len(),
+            2,
+            "expected exactly the rwasm and wasmtime strategies"
+        );
+        let mut outcomes = outcomes.into_iter();
+        (outcomes.next().unwrap(), outcomes.next().unwrap())
+    }
+}
+
+fn assert_aligned(rwasm: &Outcome, wasmtime: &Outcome) {
+    assert_eq!(
+        rwasm, wasmtime,
+        "\nrwasm and wasmtime diverged:\n  rwasm    = {rwasm:?}\n  wasmtime = {wasmtime:?}\n"
+    );
+}
+
+fn accepting_syscall_handler(
+    _caller: &mut TypedCaller<'_, ()>,
+    _sys_func_idx: u32,
+    _params: &[Value],
+    _result: &mut [Value],
+) -> Result<(), TrapCode> {
+    Ok(())
+}
+
+/// Control flow, calls, memory, globals, tables, `select`, the `i64` snippets and every syscall
+/// charging mode, on a path that runs to completion.
+#[test]
+fn fuel_matches_on_completing_path() {
+    let mut import_linker = ImportLinker::default();
+    import_linker.insert_function(
+        ImportName::new("env", "const_call"),
+        1,
+        SyscallFuelParams::Const(17),
+        &[ValType::I32],
+        &[],
+    );
+    import_linker.insert_function(
+        ImportName::new("env", "linear_call"),
+        2,
+        SyscallFuelParams::LinearFuel(LinearFuelParams {
+            base_fuel: 7,
+            param_index: 1,
+            word_cost: 5,
+        }),
+        &[ValType::I32],
+        &[],
+    );
+    import_linker.insert_function(
+        ImportName::new("env", "quadratic_call"),
+        3,
+        SyscallFuelParams::QuadraticFuel(QuadraticFuelParams {
+            local_depth: 1,
+            word_cost: 3,
+            divisor: 2,
+            fuel_denom_rate: 4,
+        }),
+        &[ValType::I32],
+        &[],
+    );
+    let run = Run {
+        wat: r#"
+        (module
+          (import "env" "const_call" (func $c (param i32)))
+          (import "env" "linear_call" (func $l (param i32)))
+          (import "env" "quadratic_call" (func $q (param i32)))
+          (type $t (func (param i32) (result i32)))
+          (memory (export "memory") 1)
+          (global $g (mut i32) (i32.const 0))
+          (table 2 funcref)
+          (elem (i32.const 0) $f $f)
+          (func $f (type $t) local.get 0 i32.const 1 i32.add)
+          (func (export "main") (param i32) (result i64)
+            (local i64)
+            ;; if / else
+            local.get 0
+            if (result i32) i32.const 7 else i32.const 9 end
+            drop
+            ;; loop with a conditional back-edge
+            (loop $l
+              global.get $g i32.const 1 i32.add global.set $g
+              global.get $g i32.const 5 i32.lt_u
+              br_if $l)
+            ;; br_table
+            (block $a (block $b
+              local.get 0 br_table $a $b)
+              i32.const 1 drop)
+            ;; direct and indirect calls
+            i32.const 1 call $f drop
+            i32.const 2 i32.const 0 call_indirect (type $t) drop
+            ;; memory
+            i32.const 0 i32.const 42 i32.store
+            i32.const 0 i32.load drop
+            memory.size drop
+            ;; select
+            i32.const 1 i32.const 2 local.get 0 select drop
+            ;; i64 operators lowered to snippets on rwasm
+            i64.const 10 i64.const 3 i64.mul i64.const 2 i64.div_s i64.const 1 i64.lt_s drop
+            ;; syscalls in every charging mode
+            i32.const 64 call $c
+            i32.const 64 call $l
+            i32.const 64 call $q
+            i64.const 5
+          )
+        )
+        "#,
+        import_linker: Arc::new(import_linker),
+        syscall_handler: accepting_syscall_handler,
+        fuel_limit: Some(10_000),
+        params: &[Value::I32(1)],
+        results: &[Value::I64(0)],
+        memory_prefix: 8,
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, None);
+    assert_eq!(rwasm.result, vec![Value::I64(5)]);
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// The caller's region is charged in full on entry, including the instructions after `call`
+/// that never run because the callee traps: 1 entry + 10 call + 6 tail in `main`, 1 entry in
+/// the callee.
+#[test]
+fn fuel_matches_when_callee_traps_and_caller_has_a_tail() {
+    let run = Run::plain(
+        r#"
+        (module
+          (func $trap unreachable)
+          (func (export "main")
+            call $trap
+            i32.const 1 i32.const 2 i32.add drop
+            i32.const 3 i32.const 4 i32.add drop
+          )
+        )
+        "#,
+        Some(1_000),
+    );
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, Some(TrapCode::UnreachableCodeReached));
+    assert_eq!(rwasm.remaining_fuel, Some(1_000 - 18));
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// A trap in the middle of a straight-line region: the whole region (1 entry + 3 operators) has
+/// already been charged and published.
+#[test]
+fn fuel_matches_when_trap_happens_mid_region() {
+    let run = Run {
+        params: &[Value::I32(0)],
+        results: &[Value::I32(0)],
+        ..Run::plain(
+            r#"
+            (module
+              (func (export "main") (param i32) (result i32)
+                i32.const 1
+                local.get 0
+                i32.div_u
+              )
+            )
+            "#,
+            Some(1_000),
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, Some(TrapCode::IntegerDivisionByZero));
+    assert_eq!(rwasm.remaining_fuel, Some(1_000 - 4));
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// Disabled float operators trap on both engines after charging the code up to and including
+/// the operator (1 entry + `f32.const` + `f32.sqrt`); the dead tail behind the trap is neither
+/// translated nor charged.
+#[cfg(not(feature = "fpu"))]
+#[test]
+fn fuel_matches_after_disabled_float_opcode() {
+    let run = Run {
+        results: &[Value::I32(0)],
+        ..Run::plain(
+            r#"
+            (module
+              (func (export "main") (result i32)
+                f32.const 1
+                f32.sqrt
+                drop
+                i32.const 1 i32.const 2 i32.add
+              )
+            )
+            "#,
+            Some(1_000),
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, Some(TrapCode::IllegalOpcode));
+    assert_eq!(rwasm.remaining_fuel, Some(1_000 - 3));
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// A leaf function whose straight-line cost (1 entry + 21 operators) exceeds the limit of 10.
+/// Neither engine enters the region: both trap with `OutOfFuel` and leave the limit untouched.
+#[test]
+fn out_of_fuel_matches_on_straight_line_overrun() {
+    let run = Run {
+        results: &[Value::I32(0)],
+        ..Run::plain(
+            r#"
+            (module
+              (func (export "main") (result i32)
+                i32.const 0
+                i32.const 1 i32.add
+                i32.const 1 i32.add
+                i32.const 1 i32.add
+                i32.const 1 i32.add
+                i32.const 1 i32.add
+                i32.const 1 i32.add
+                i32.const 1 i32.add
+                i32.const 1 i32.add
+                i32.const 1 i32.add
+                i32.const 1 i32.add
+              )
+            )
+            "#,
+            Some(10),
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, Some(TrapCode::OutOfFuel));
+    assert_eq!(rwasm.remaining_fuel, Some(10));
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// One iteration costs 9, entry costs 1, limit is 30: both engines complete exactly 3 iterations
+/// (observable in memory), refuse the 4th at the loop header and keep the 2 fuel left over.
+#[test]
+fn out_of_fuel_matches_inside_loop() {
+    let run = Run {
+        memory_prefix: 4,
+        ..Run::plain(
+            r#"
+            (module
+              (memory (export "memory") 1)
+              (func (export "main")
+                (loop $l
+                  i32.const 0
+                  i32.const 0 i32.load
+                  i32.const 1 i32.add
+                  i32.store
+                  br $l
+                )
+              )
+            )
+            "#,
+            Some(30),
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, Some(TrapCode::OutOfFuel));
+    assert_eq!(rwasm.remaining_fuel, Some(2));
+    assert_eq!(rwasm.memory, vec![3, 0, 0, 0]);
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// `fuel_limit: None` runs unbounded and reports no remaining fuel on both engines.
+#[test]
+fn unbounded_fuel_mode_matches() {
+    let run = Run {
+        results: &[Value::I32(0)],
+        ..Run::plain(
+            r#"
+            (module
+              (func (export "main") (result i32)
+                i32.const 40 i32.const 2 i32.add
+              )
+            )
+            "#,
+            None,
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, None);
+    assert_eq!(rwasm.result, vec![Value::I32(42)]);
+    assert_eq!(rwasm.remaining_fuel, None);
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// `LinearFuelParams::param_index` counts parameters from the last one, so with an `i64`
+/// parameter above the metered `i32` both engines still meter the `i32`: 320 bytes are 10 words,
+/// on top of 1 entry + 2 constants + 10 call.
+#[test]
+fn syscall_linear_param_index_matches_with_i64_params() {
+    let mut import_linker = ImportLinker::default();
+    import_linker.insert_function(
+        ImportName::new("env", "linear_call"),
+        1,
+        SyscallFuelParams::LinearFuel(LinearFuelParams {
+            base_fuel: 0,
+            param_index: 2,
+            word_cost: 1,
+        }),
+        &[ValType::I32, ValType::I64],
+        &[],
+    );
+    let run = Run {
+        import_linker: Arc::new(import_linker),
+        syscall_handler: accepting_syscall_handler,
+        ..Run::plain(
+            r#"
+            (module
+              (import "env" "linear_call" (func $l (param i32 i64)))
+              (func (export "main")
+                i32.const 320
+                i64.const 0
+                call $l
+              )
+            )
+            "#,
+            Some(1_000),
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, None);
+    assert_eq!(rwasm.remaining_fuel, Some(1_000 - 23));
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+fn halting_syscall_handler(
+    _caller: &mut TypedCaller<'_, ()>,
+    _sys_func_idx: u32,
+    _params: &[Value],
+    _result: &mut [Value],
+) -> Result<(), TrapCode> {
+    Err(TrapCode::ExecutionHalted)
+}
+
+fn consuming_syscall_handler(
+    caller: &mut TypedCaller<'_, ()>,
+    _sys_func_idx: u32,
+    _params: &[Value],
+    _result: &mut [Value],
+) -> Result<(), TrapCode> {
+    caller.try_consume_fuel(500)
+}
+
+fn unbounded_consuming_syscall_handler(
+    caller: &mut TypedCaller<'_, ()>,
+    _sys_func_idx: u32,
+    _params: &[Value],
+    _result: &mut [Value],
+) -> Result<(), TrapCode> {
+    caller.try_consume_fuel(1_000_000)
+}
+
+fn linker_with_one_import(name: &'static str, fuel: SyscallFuelParams) -> Arc<ImportLinker> {
+    let mut import_linker = ImportLinker::default();
+    import_linker.insert_function(ImportName::new("env", name), 1, fuel, &[], &[]);
+    Arc::new(import_linker)
+}
+
+/// Consuming exactly the limit is not out of fuel: 1 entry + 3 operators against a limit of 4.
+#[test]
+fn exact_limit_matches() {
+    let run = Run {
+        results: &[Value::I32(0)],
+        ..Run::plain(
+            r#"
+            (module
+              (func (export "main") (result i32)
+                i32.const 40 i32.const 2 i32.add
+              )
+            )
+            "#,
+            Some(4),
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, None);
+    assert_eq!(rwasm.result, vec![Value::I32(42)]);
+    assert_eq!(rwasm.remaining_fuel, Some(0));
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// The caller's region (1 entry + 10 call) fits in the limit of 15 but the callee's (1 entry +
+/// 5 operators) does not: both engines trap at the callee's entry and keep the caller's charge.
+#[test]
+fn out_of_fuel_matches_at_callee_entry() {
+    let run = Run {
+        results: &[Value::I32(0)],
+        ..Run::plain(
+            r#"
+            (module
+              (func $callee (result i32)
+                i32.const 1 i32.const 2 i32.add i32.const 3 i32.add
+              )
+              (func (export "main") (result i32) call $callee)
+            )
+            "#,
+            Some(15),
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, Some(TrapCode::OutOfFuel));
+    assert_eq!(rwasm.remaining_fuel, Some(15 - 11));
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// A failing host call: the caller's region (1 entry + 10 call + 1 tail) and the syscall's
+/// constant fuel (5) are both charged before the host runs.
+#[test]
+fn fuel_matches_when_host_call_fails() {
+    let run = Run {
+        import_linker: linker_with_one_import("fail", SyscallFuelParams::Const(5)),
+        ..Run::plain(
+            r#"
+            (module
+              (import "env" "fail" (func $f))
+              (func (export "main") call $f i32.const 1 drop)
+            )
+            "#,
+            Some(1_000),
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, Some(TrapCode::UnknownExternalFunction));
+    assert_eq!(rwasm.remaining_fuel, Some(1_000 - 17));
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// A host call that halts execution counts as success on both engines; the caller's tail after
+/// the call (3 operators) was already charged with the region.
+#[test]
+fn fuel_matches_on_execution_halt_with_tail() {
+    let run = Run {
+        import_linker: linker_with_one_import("exit", SyscallFuelParams::None),
+        syscall_handler: halting_syscall_handler,
+        ..Run::plain(
+            r#"
+            (module
+              (import "env" "exit" (func $e))
+              (func (export "main") call $e i32.const 1 i32.const 2 i32.add drop)
+            )
+            "#,
+            Some(1_000),
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, None);
+    assert_eq!(rwasm.remaining_fuel, Some(1_000 - 14));
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// `call_indirect` through a null table entry traps after its region (1 entry + 1 const + 10
+/// call + 1 tail) was charged.
+#[test]
+fn fuel_matches_when_call_indirect_traps() {
+    let run = Run::plain(
+        r#"
+        (module
+          (type $t (func))
+          (table 1 funcref)
+          (func (export "main") i32.const 0 call_indirect (type $t) i32.const 1 drop)
+        )
+        "#,
+        Some(1_000),
+    );
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, Some(TrapCode::IndirectCallToNull));
+    assert_eq!(rwasm.remaining_fuel, Some(1_000 - 13));
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// An out-of-bounds load in the middle of a region: 1 entry + 1 const + 2 load + 1 const + 1 add.
+#[test]
+fn fuel_matches_on_memory_out_of_bounds_load() {
+    let run = Run {
+        results: &[Value::I32(0)],
+        ..Run::plain(
+            r#"
+            (module
+              (memory (export "memory") 1)
+              (func (export "main") (result i32)
+                i32.const 70000 i32.load i32.const 1 i32.add
+              )
+            )
+            "#,
+            Some(1_000),
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, Some(TrapCode::MemoryOutOfBounds));
+    assert_eq!(rwasm.remaining_fuel, Some(1_000 - 6));
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// Every `end` opens a new region on both engines. Depending on the `br_table` target the trap
+/// lands in the region after the inner `end` (1 operator) or after the outer `end` (2
+/// operators), on top of the function region (1 entry + `local.get` + `br_table`).
+#[test]
+fn fuel_matches_across_br_table_targets_and_block_ends() {
+    let wat = r#"
+        (module
+          (func (export "main") (param i32)
+            (block $a
+              (block $b
+                local.get 0
+                br_table $b $a)
+              i32.const 1 drop
+              unreachable)
+            i32.const 2 drop
+            i32.const 3 drop
+            unreachable
+          )
+        )
+        "#;
+    for (param, consumed) in [(0, 4), (1, 5)] {
+        let run = Run {
+            params: &[Value::I32(param)],
+            ..Run::plain(wat, Some(1_000))
+        };
+        let (rwasm, wasmtime) = run.execute();
+        assert_eq!(rwasm.trap, Some(TrapCode::UnreachableCodeReached));
+        assert_eq!(
+            rwasm.remaining_fuel,
+            Some(1_000 - consumed),
+            "param {param}"
+        );
+        assert_aligned(&rwasm, &wasmtime);
+    }
+}
+
+/// A loop with a conditional back-edge: every iteration is one header region (8 for the store,
+/// 5 for the compare, 1 for `br_if`) and the fall-through after `br_if` is its own region. With
+/// a limit of 40 both engines complete 2 iterations, refuse the 3rd header and keep 11 fuel.
+#[test]
+fn out_of_fuel_matches_in_loop_with_conditional_back_edge() {
+    let run = Run {
+        memory_prefix: 4,
+        ..Run::plain(
+            r#"
+            (module
+              (memory (export "memory") 1)
+              (func (export "main")
+                (loop $l
+                  i32.const 0 i32.const 0 i32.load i32.const 1 i32.add i32.store
+                  i32.const 0 i32.load i32.const 100 i32.lt_u
+                  br_if $l)
+                i32.const 0 i32.const 0 i32.load i32.const 1000 i32.add i32.store
+              )
+            )
+            "#,
+            Some(40),
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, Some(TrapCode::OutOfFuel));
+    assert_eq!(rwasm.remaining_fuel, Some(40 - 29));
+    assert_eq!(rwasm.memory, vec![2, 0, 0, 0]);
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// `if` without `else`: the function region (1 entry + `local.get` + `if`), the `then` arm (2)
+/// and the region after `end` (1) are charged only on the path taken.
+#[test]
+fn fuel_matches_in_if_without_else_on_both_paths() {
+    let wat = r#"
+        (module
+          (func (export "main") (param i32) (result i32)
+            local.get 0
+            if
+              i32.const 1 drop i32.const 2 drop
+            end
+            i32.const 7
+          )
+        )
+        "#;
+    for (param, consumed) in [(1, 6), (0, 4)] {
+        let run = Run {
+            params: &[Value::I32(param)],
+            results: &[Value::I32(0)],
+            ..Run::plain(wat, Some(1_000))
+        };
+        let (rwasm, wasmtime) = run.execute();
+        assert_eq!(rwasm.trap, None);
+        assert_eq!(rwasm.result, vec![Value::I32(7)]);
+        assert_eq!(
+            rwasm.remaining_fuel,
+            Some(1_000 - consumed),
+            "param {param}"
+        );
+        assert_aligned(&rwasm, &wasmtime);
+    }
+}
+
+/// Tail-call recursion until the fuel runs out. `main` costs 1 + 1 + 10; every recursive frame
+/// costs 4 on entry (entry, `local.get`, `i32.eqz`, `if`) and 13 after the `end` (`local.get`,
+/// `i32.const`, `i32.sub`, `return_call`). The 12th frame's entry does not fit in a limit of 200.
+#[test]
+fn out_of_fuel_matches_in_tail_call_recursion() {
+    let run = Run {
+        results: &[Value::I32(0)],
+        ..Run::plain(
+            r#"
+            (module
+              (func $rec (param i32) (result i32)
+                local.get 0 i32.eqz
+                if
+                  i32.const 0 return
+                end
+                local.get 0 i32.const 1 i32.sub
+                return_call $rec
+              )
+              (func (export "main") (result i32) i32.const 1000 return_call $rec)
+            )
+            "#,
+            Some(200),
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, Some(TrapCode::OutOfFuel));
+    assert_eq!(rwasm.remaining_fuel, Some(200 - 199));
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// A host call that tries to consume 500 fuel against a limit of 100: the host's charge is
+/// refused on both engines and only the region charge (1 entry + 10 call) stays consumed.
+#[test]
+fn out_of_fuel_matches_when_host_consumes_fuel() {
+    let run = Run {
+        import_linker: linker_with_one_import("burn", SyscallFuelParams::None),
+        syscall_handler: consuming_syscall_handler,
+        ..Run::plain(
+            r#"
+            (module
+              (import "env" "burn" (func $b))
+              (func (export "main") call $b)
+            )
+            "#,
+            Some(100),
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, Some(TrapCode::OutOfFuel));
+    assert_eq!(rwasm.remaining_fuel, Some(100 - 11));
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// In unbounded mode the host can consume any amount of fuel on both engines.
+#[test]
+fn unbounded_fuel_mode_matches_with_host_consumption() {
+    let run = Run {
+        import_linker: linker_with_one_import("burn", SyscallFuelParams::None),
+        syscall_handler: unbounded_consuming_syscall_handler,
+        ..Run::plain(
+            r#"
+            (module
+              (import "env" "burn" (func $b))
+              (func (export "main") call $b)
+            )
+            "#,
+            None,
+        )
+    };
+    let (rwasm, wasmtime) = run.execute();
+    assert_eq!(rwasm.trap, None);
+    assert_eq!(rwasm.remaining_fuel, None);
+    assert_aligned(&rwasm, &wasmtime);
+}
+
+/// `reset_fuel` gives the same executor a fresh limit on both engines, including one that is
+/// too small for the next run.
+#[test]
+fn reset_fuel_matches() {
+    let run = Run::plain(
+        r#"
+        (module
+          (func (export "main") (result i32) i32.const 40 i32.const 2 i32.add)
+        )
+        "#,
+        Some(100),
+    );
+    let wasm_binary = wat::parse_str(run.wat).unwrap();
+    let outcomes = for_each_strategy(
+        |strategy| {
+            let mut executor = strategy.create_executor(
+                run.import_linker.clone(),
+                (),
+                run.syscall_handler,
+                run.fuel_limit,
+                None,
+            )?;
+            let mut observed = Vec::new();
+            for limit in [None, Some(50), Some(3)] {
+                if let Some(limit) = limit {
+                    executor.reset_fuel(limit);
+                }
+                let mut result = [Value::I32(0)];
+                let trap = executor.execute("main", &[], &mut result).err();
+                observed.push((trap, executor.remaining_fuel(), result[0].clone()));
+            }
+            Ok(observed)
+        },
+        run.config(),
+        &wasm_binary,
+    )
+    .unwrap();
+    assert_eq!(
+        outcomes[0],
+        vec![
+            (None, Some(96), Value::I32(42)),
+            (None, Some(46), Value::I32(42)),
+            (Some(TrapCode::OutOfFuel), Some(3), Value::I32(0)),
+        ]
+    );
+    assert_eq!(outcomes[0], outcomes[1], "rwasm and wasmtime diverged");
+}


### PR DESCRIPTION
## Summary

Second half of FLU-143. The Wasmtime side landed in fluentlabs-xyz/wasmtime#11 (published as `wasmtime-rwasm` 45.0.0-rwasm.2); this PR bumps to it and closes the remaining gaps on the rwasm side, so both engines burn the same fuel, stop at the same point and report the same remaining fuel on every path.

### Changes

- **Dependency**: `wasmtime-rwasm` 45.0.0-rwasm.2 (region-based eager charging aligned with the rwasm translator, refused charges never applied, refuel/async yields preserved).
- **Unbounded mode** (`src/wasmtime/context.rs`, `src/wasmtime/instance.rs`): `fuel_limit: None` fills the store with `u64::MAX` and flags it, so `remaining_fuel()` is `None` like the rwasm store instead of an immediate `OutOfFuel`. Layered on the shared fuel helpers from #201.
- **Syscall fuel parameter addressing** (`src/compiler/block_fuel.rs`, `parser.rs`, `error.rs`): `param_index`/`local_depth` are parameter positions counted from the last parameter, as Wasmtime reads them; the trampoline converts to a slot depth, skipping two slots per `i64`/`f64` above the metered parameter. Out-of-range positions return the new `CompilationError::InvalidSyscallFuelParam`.
- **Disabled float operators** (`src/compiler/translator.rs`): the path ends after the injected `Trap(IllegalOpcode)`, so the dead tail is neither emitted nor charged, matching Wasmtime.
- **Tests**: `tests/fuel_alignment.rs`, 21 differential WAT cases on both engines with absolute numbers pinned.
- **Docs**: engine-alignment section in `docs/vm-and-fuel.md`.

### Behaviour changes worth knowing

- Modules containing float operators in non-`fpu` builds lose the dead bytecode after the trap.
- Import trampolines whose syscall config has an `i64`/`f64` parameter above the metered one now meter the right value (they previously read half of the `i64`). Worth checking the fluentbase import linker for such signatures.
- Only `consume_fuel_for_bulk_ops` and `consume_fuel_for_params_and_locals` remain rwasm-only (FLU-1357).

### Testing

Full root suite, e2e spec testsuite (92 groups), snippets, nitro verifier, clippy with all features, rustfmt; the same under `fpu` + `full-wasm-mode`; `cargo fuzz run differential` with no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved fuel handling for unlimited execution, fuel resets, loops, calls, memory operations, and host interactions.
  - Fuel behavior is now aligned across supported execution engines, including consistent out-of-fuel traps and remaining-fuel reporting.
  - Invalid fuel parameter references now produce a clear compilation error.
  - Unsupported floating-point operations now stop execution cleanly without charging subsequent instructions.

- **Documentation**
  - Added guidance on cross-engine fuel behavior, compatibility settings, and testing.

- **Tests**
  - Added comprehensive cross-engine tests covering fuel usage, traps, control flow, memory, and unbounded execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->