### PR TITLE
fix: close the rWasm audit 2026-09-09 findings (FLU-1355)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,15 +933,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,7 +1313,6 @@ dependencies = [
  "rwasm-fuel-policy",
  "serde",
  "smallvec",
- "spin",
  "tiny-keccak",
  "wasmparser-nostd",
  "wasmtime-rwasm",
@@ -1346,12 +1336,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1445,15 +1429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "spin"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abadc99fd9c7bbb7d0ca2b31d72a067d0c0dcd7aad25ab8cac71ba91417694b"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 libm = "0.2.1"
 smallvec = "1.15.0"
 num-derive = "0.5.1"
-spin = "0.12.2"
 
 # tracing
 serde = { version = "1.0.219", features = ["derive", "rc"], optional = true }

--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ The full walk-through lives in [pipeline.md](./docs/pipeline.md) and [architectu
 
 Anything consensus-critical that may run on either backend must be compiled with a strategy-compatible
 configuration such as `CompilationConfig::default_strategy_compatible()`. The plain `default()` enables two fuel
-injections that only the interpreter implements, so the same module would burn different fuel on the two engines.
-Details are in [vm-and-fuel.md](./docs/vm-and-fuel.md#engine-alignment).
+injections that only the interpreter implements, so the same module would burn different fuel on the two engines;
+`StrategyDefinition::new` and `new_as_wasmtime` reject such a config with `CompilationError::StrategyIncompatibleConfig`
+(`new_as_rwasm` accepts it). Details are in [vm-and-fuel.md](./docs/vm-and-fuel.md#engine-alignment).
 
 ## Fuel
 

--- a/docs/security-considerations.md
+++ b/docs/security-considerations.md
@@ -22,6 +22,26 @@ Examples:
 
 So malicious inputs are expected to produce controlled failures (validation errors/traps), not undefined behavior execution.
 
+## Panic-free entry points
+
+A node embedding `rwasm` should not need a `catch_unwind` net around the guest-facing API. The
+following entry points report every failure on guest-controlled input as a `Result`:
+
+- compilation: `RwasmModule::compile`, `ModuleParser::parse`, `StrategyDefinition::new`,
+  `new_as_rwasm`, `new_as_wasmtime`, `compile_wasmtime_module`, `compile_wasmtime_module_cached`
+- decoding of serialized rWasm: `RwasmModule::new_checked`, `RwasmModule::new_checked_exact`
+- instantiation: `StrategyDefinition::create_executor`, `ImportLinker::instantiate`,
+  `WasmtimeExecutor::new`, `WasmtimeExecutor::try_new`
+- execution: `ExecutionEngine::execute`, `ExecutionEngine::resume` (an error, not a panic, when
+  there is no interrupted execution to resume), `StrategyExecutor::execute`,
+  `StrategyExecutor::resume`, and the `StoreTr` memory and fuel accessors
+
+The remaining panics are deliberate fail-fast checks on host-supplied configuration, documented on
+each function: `RwasmModule::new` and `RwasmModule::serialize` (a trusted rWasm artifact that does
+not decode or encode), `ImportLinker::insert_*` (duplicate import names or syscall indices in the
+host's own linker), `GlobalMemory::new` and `ValueStack::new` (inconsistent host-chosen limits).
+None of them is reachable from a module or from guest execution.
+
 ## Host boundary
 
 Security of total execution depends on both VM semantics and host integrations:

--- a/docs/vm-and-fuel.md
+++ b/docs/vm-and-fuel.md
@@ -56,8 +56,12 @@ per-operator schedule lives in the shared `rwasm-fuel-policy` crate. Both engine
   slots those parameters occupy.
 
 Only `consume_fuel_for_bulk_ops` and `consume_fuel_for_params_and_locals` remain rwasm-only; use
-`CompilationConfig::default_strategy_compatible` for modules that may run on either engine.
-`tests/fuel_alignment.rs` pins these invariants differentially.
+`CompilationConfig::default_strategy_compatible` for modules that may run on either engine. The
+strategy-agnostic constructors (`StrategyDefinition::new`, `StrategyDefinition::new_as_wasmtime`,
+`for_each_strategy`) reject a config that enables either flag with
+`CompilationError::StrategyIncompatibleConfig`; only `StrategyDefinition::new_as_rwasm` and
+`RwasmModule::compile` accept it, because the rwasm VM is the one engine that implements the
+injections. `tests/fuel_alignment.rs` pins these invariants differentially.
 
 ## Traps and errors
 

--- a/e2e/src/group.rs
+++ b/e2e/src/group.rs
@@ -101,7 +101,7 @@ impl TestingInstanceWasmtime {
             testing_context_syscall_handler,
             Some(u64::MAX),
             None,
-        );
+        )?;
         Ok(TestingInstanceWasmtime { store })
     }
 

--- a/src/compiler/compiled_expr.rs
+++ b/src/compiler/compiled_expr.rs
@@ -1,19 +1,20 @@
 #![allow(dead_code)]
 
-//! Data structures to represents Wasm constant expressions.
+//! Data structures to represent Wasm constant expressions.
 //!
 //! This has built-in support for the `extended-const` Wasm proposal.
-//! The design of the execution mechanic was inspired by the [`s1vm`]
-//! virtual machine architecture.
 //!
-//! [`s1vm`]: https://github.com/Neopallium/s1vm
+//! A [`CompiledExpr`] keeps its operators in postfix order and evaluates them with an explicit
+//! operand stack, so constructing, evaluating and dropping an expression never recurses. With
+//! `extended-const` a validated expression may be an arbitrarily long operator chain, and a tree of
+//! nested closures (one per operator) overflowed the compiler's native stack on such input long
+//! before any fuel could be charged.
 
-use crate::{ExternRef, FuncIdx, FuncRef, GlobalIdx, Value, F32, F64};
-use alloc::boxed::Box;
+use crate::{CompilationError, ExternRef, FuncIdx, FuncRef, GlobalIdx, Value, F32, F64};
 use smallvec::SmallVec;
 use wasmparser::ConstExpr;
 
-/// Types that allow evluation given an evaluation context.
+/// Types that allow evaluation given an evaluation context.
 pub trait Eval {
     /// Evaluates `self` given an [`EvalContext`].
     fn eval(&self, ctx: &dyn EvalContext) -> Option<i64>;
@@ -42,112 +43,48 @@ impl EvalContext for EmptyEvalContext {
     }
 }
 
-/// An input parameter to a [`CompiledExpr`] operator.
-#[derive(Debug)]
-pub enum Op {
-    /// A constant value.
-    Const(ConstOp),
-    /// The value of a global variable.
-    Global(GlobalOp),
-    /// A Wasm `ref.func index` value.
-    FuncRef(FuncRefOp),
-    /// An arbitrary expression.
-    Expr(ExprOp),
+/// A binary operator of the `extended-const` proposal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOp {
+    /// `i32.add`
+    I32Add,
+    /// `i32.sub`
+    I32Sub,
+    /// `i32.mul`
+    I32Mul,
+    /// `i64.add`
+    I64Add,
+    /// `i64.sub`
+    I64Sub,
+    /// `i64.mul`
+    I64Mul,
 }
 
-impl Clone for Op {
-    fn clone(&self) -> Self {
+impl BinaryOp {
+    /// Applies the operator to its two operands.
+    fn apply(self, lhs: i64, rhs: i64) -> i64 {
         match self {
-            Op::Const(op) => Op::Const(op.clone()),
-            Op::Global(op) => Op::Global(*op),
-            Op::FuncRef(op) => Op::FuncRef(*op),
-            Op::Expr(_) => unreachable!("cloning of expr is not possible"),
+            Self::I32Add => i32::wrapping_add(lhs as i32, rhs as i32) as i64,
+            Self::I32Sub => i32::wrapping_sub(lhs as i32, rhs as i32) as i64,
+            Self::I32Mul => i32::wrapping_mul(lhs as i32, rhs as i32) as i64,
+            Self::I64Add => lhs.wrapping_add(rhs),
+            Self::I64Sub => lhs.wrapping_sub(rhs),
+            Self::I64Mul => lhs.wrapping_mul(rhs),
         }
     }
 }
 
-/// A constant value operator.
-///
-/// This may represent the following Wasm operators:
-///
-/// - `i32.const`
-/// - `i64.const`
-/// - `f32.const`
-/// - `f64.const`
-/// - `ref.null`
-#[derive(Debug, Clone)]
-pub struct ConstOp {
-    /// The underlying precomputed untyped value.
-    value: i64,
-}
-
-impl Eval for ConstOp {
-    fn eval(&self, _ctx: &dyn EvalContext) -> Option<i64> {
-        Some(self.value)
-    }
-}
-
-/// Represents a Wasm `global.get` operator.
-
-#[derive(Debug, Copy, Clone)]
-pub struct GlobalOp {
-    /// The index of the global variable.
-    global_index: u32,
-}
-
-impl Eval for GlobalOp {
-    fn eval(&self, ctx: &dyn EvalContext) -> Option<i64> {
-        ctx.get_global(self.global_index).map(|v| match v {
-            Value::I32(value) => value as i64,
-            Value::I64(value) => value,
-            Value::F32(value) => value.to_bits() as u64 as i64,
-            Value::F64(value) => value.to_bits() as i64,
-            Value::FuncRef(value) => value.0 as i32 as i64,
-            Value::ExternRef(value) => value.0 as i32 as i64,
-        })
-    }
-}
-
-/// Represents a Wasm `func.ref` operator.
-
-#[derive(Debug, Copy, Clone)]
-pub struct FuncRefOp {
-    /// The index of the function.
-    function_index: u32,
-}
-
-impl Eval for FuncRefOp {
-    fn eval(&self, ctx: &dyn EvalContext) -> Option<i64> {
-        ctx.get_func(self.function_index).map(|v| v.0 as i64)
-    }
-}
-
-/// A generic Wasm expression operator.
-///
-/// This may represent one of the following Wasm operators:
-///
-/// - `i32.add`
-/// - `i32.sub`
-/// - `i32.mul`
-/// - `i64.add`
-/// - `i64.sub`
-/// - `i64.mul`
-#[allow(clippy::type_complexity)]
-pub struct ExprOp {
-    /// The underlying closure that implements the expression.
-    expr: Box<dyn Fn(&dyn EvalContext) -> Option<i64> + Send>,
-}
-
-impl core::fmt::Debug for ExprOp {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ExprOp").finish()
-    }
-}
-
-impl Eval for ExprOp {
-    fn eval(&self, ctx: &dyn EvalContext) -> Option<i64> {
-        (self.expr)(ctx)
-    }
+/// One operator of a [`CompiledExpr`], stored in evaluation (postfix) order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Op {
+    /// A constant value: `i32.const`, `i64.const`, `f32.const`, `f64.const` or `ref.null`.
+    Const(i64),
+    /// The value of a global variable: `global.get index`.
+    Global(u32),
+    /// A Wasm `ref.func index` value.
+    FuncRef(u32),
+    /// A binary operator over the two topmost operands.
+    Binary(BinaryOp),
 }
 
 impl Op {
@@ -165,38 +102,29 @@ impl Op {
             Value::FuncRef(value) => value.0 as i64,
             Value::ExternRef(value) => value.0 as i64,
         };
-        Self::Const(ConstOp { value })
+        Self::Const(value)
     }
 
     /// Creates a new global operator with the given index.
     pub fn global(global_index: u32) -> Self {
-        Self::Global(GlobalOp { global_index })
+        Self::Global(global_index)
     }
 
-    /// Creates a new global operator with the given index.
+    /// Creates a new `ref.func` operator with the given index.
     pub fn funcref(function_index: u32) -> Self {
-        Self::FuncRef(FuncRefOp { function_index })
-    }
-
-    /// Creates a new expression operator for the given `expr`.
-    pub fn expr<T>(expr: T) -> Self
-    where
-        T: Fn(&dyn EvalContext) -> Option<i64> + Send + 'static,
-    {
-        Self::Expr(ExprOp {
-            expr: Box::new(expr),
-        })
+        Self::FuncRef(function_index)
     }
 }
 
-impl Eval for Op {
-    fn eval(&self, ctx: &dyn EvalContext) -> Option<i64> {
-        match self {
-            Op::Const(op) => op.eval(ctx),
-            Op::Global(op) => op.eval(ctx),
-            Op::FuncRef(op) => op.eval(ctx),
-            Op::Expr(op) => op.eval(ctx),
-        }
+/// Returns the bits of a global variable's value as seen by a constant expression.
+fn global_bits(value: Value) -> i64 {
+    match value {
+        Value::I32(value) => value as i64,
+        Value::I64(value) => value,
+        Value::F32(value) => value.to_bits() as u64 as i64,
+        Value::F64(value) => value.to_bits() as i64,
+        Value::FuncRef(value) => value.0 as i32 as i64,
+        Value::ExternRef(value) => value.0 as i32 as i64,
     }
 }
 
@@ -207,147 +135,111 @@ impl Eval for Op {
 /// of global variables.
 #[derive(Debug, Clone)]
 pub struct CompiledExpr {
-    /// The root operator of the [`CompiledExpr`].
-    pub(crate) op: Op,
+    /// The operators in postfix order.
+    ///
+    /// Wasm validation guarantees that evaluating them leaves exactly one value on the operand
+    /// stack; [`CompiledExpr::new`] re-checks that so [`Eval::eval`] is total.
+    ops: SmallVec<[Op; 1]>,
 }
 
 impl Eval for CompiledExpr {
     fn eval(&self, ctx: &dyn EvalContext) -> Option<i64> {
-        self.op.eval(ctx)
+        let mut stack = SmallVec::<[i64; 4]>::new();
+        for op in &self.ops {
+            let value = match *op {
+                Op::Const(value) => value,
+                Op::Global(global_index) => global_bits(ctx.get_global(global_index)?),
+                Op::FuncRef(function_index) => ctx.get_func(function_index)?.0 as i64,
+                Op::Binary(op) => {
+                    let rhs = stack.pop()?;
+                    let lhs = stack.pop()?;
+                    op.apply(lhs, rhs)
+                }
+            };
+            stack.push(value);
+        }
+        let result = stack.pop()?;
+        stack.is_empty().then_some(result)
     }
-}
-
-macro_rules! def_expr {
-    ($lhs:ident, $rhs:ident, $expr:expr) => {{
-        Op::expr(move |ctx: &dyn EvalContext| -> Option<i64> {
-            let lhs = $lhs.eval(ctx)?;
-            let rhs = $rhs.eval(ctx)?;
-            Some($expr(lhs, rhs))
-        })
-    }};
 }
 
 impl CompiledExpr {
     pub fn zero() -> Self {
-        Self {
-            op: Op::Const(ConstOp {
-                value: Default::default(),
-            }),
-        }
+        Self::from_const(0)
     }
 
     pub fn from_const(value: i64) -> Self {
-        Self {
-            op: Op::Const(ConstOp { value }),
-        }
+        Self::from_op(Op::Const(value))
     }
 
-    /// Creates a new [`CompiledExpr`] from the given Wasm [`CompiledExpr`].
+    fn from_op(op: Op) -> Self {
+        let mut ops = SmallVec::new();
+        ops.push(op);
+        Self { ops }
+    }
+
+    /// Creates a new [`CompiledExpr`] from the given Wasm [`ConstExpr`].
     ///
     /// # Note
     ///
-    /// The constructor assumes that Wasm validation already succeeded
-    /// on the input Wasm [`CompiledExpr`].
-    pub fn new(expr: ConstExpr<'_>) -> Self {
-        /// A buffer required for translation of Wasm const expressions.
-        type TranslationBuffer = SmallVec<[Op; 3]>;
-        /// Convenience function to create the various expression operators.
-        fn expr_op(stack: &mut TranslationBuffer, expr: fn(i64, i64) -> i64) {
-            let rhs = stack
-                .pop()
-                .expect("must have rhs operator on the stack due to Wasm validation");
-            let lhs = stack
-                .pop()
-                .expect("must have lhs operator on the stack due to Wasm validation");
-            let op = match (lhs, rhs) {
-                (Op::Const(lhs), Op::Const(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::Const(lhs), Op::Global(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::Const(lhs), Op::FuncRef(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::Const(lhs), Op::Expr(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::Global(lhs), Op::Const(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::Global(lhs), Op::Global(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::Global(lhs), Op::FuncRef(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::Global(lhs), Op::Expr(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::FuncRef(lhs), Op::Const(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::FuncRef(lhs), Op::Global(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::FuncRef(lhs), Op::FuncRef(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::FuncRef(lhs), Op::Expr(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::Expr(lhs), Op::Const(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::Expr(lhs), Op::Global(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::Expr(lhs), Op::FuncRef(rhs)) => def_expr!(lhs, rhs, expr),
-                (Op::Expr(lhs), Op::Expr(rhs)) => def_expr!(lhs, rhs, expr),
-            };
-            stack.push(op);
-        }
-
+    /// The constructor assumes that Wasm validation already succeeded on the input, and it reads
+    /// the operators in one pass: the operator count is bounded only by the module size, so it is
+    /// never used as a recursion depth.
+    ///
+    /// # Errors
+    ///
+    /// - [`CompilationError::MalformedWasmBinary`] if the operator encoding is malformed.
+    /// - [`CompilationError::NotSupportedOpcode`] for an operator outside the constant subset.
+    /// - [`CompilationError::ConstEvaluationFailed`] if the operators do not leave exactly one
+    ///   value on the operand stack.
+    ///
+    /// Wasm validation rules all three out, so hitting one means the validator and the translator
+    /// disagree on the accepted language; the error keeps that a rejected module rather than a
+    /// panic.
+    pub fn new(expr: ConstExpr<'_>) -> Result<Self, CompilationError> {
         let mut reader = expr.get_operators_reader();
-        // TODO: we might want to avoid heap allocation in the simple cases that
-        //       only have one operator via the small vector data structure.
-        let mut stack = TranslationBuffer::new();
+        let mut ops = SmallVec::new();
+        // the operand-stack height a stack machine would have after the operators read so far
+        let mut height: usize = 0;
         loop {
-            let op = reader.read().unwrap_or_else(|error| {
-                panic!("unexpectedly encountered invalid const expression operator: {error}")
-            });
-            match op {
-                wasmparser::Operator::I32Const { value } => {
-                    stack.push(Op::constant(value));
-                }
-                wasmparser::Operator::I64Const { value } => {
-                    stack.push(Op::constant(value));
-                }
-                wasmparser::Operator::F32Const { value } => {
-                    stack.push(Op::constant(F32::from(value.bits())));
-                }
-                wasmparser::Operator::F64Const { value } => {
-                    stack.push(Op::constant(F64::from(value.bits())));
-                }
-                wasmparser::Operator::GlobalGet { global_index } => {
-                    stack.push(Op::global(global_index));
-                }
-                wasmparser::Operator::RefNull { ty } => {
-                    let value = match ty {
-                        wasmparser::ValType::FuncRef => Value::from(FuncRef::null()),
-                        wasmparser::ValType::ExternRef => Value::from(ExternRef::null()),
-                        ty => panic!("encountered an invalid value type for RefNull: {ty:?}"),
-                    };
-                    stack.push(Op::constant(value));
-                }
-                wasmparser::Operator::RefFunc { function_index } => {
-                    stack.push(Op::funcref(function_index));
-                }
-                wasmparser::Operator::I32Add => expr_op(&mut stack, |lhs, rhs| {
-                    i32::wrapping_add(lhs as i32, rhs as i32) as i64
-                }),
-                wasmparser::Operator::I32Sub => expr_op(&mut stack, |lhs, rhs| {
-                    i32::wrapping_sub(lhs as i32, rhs as i32) as i64
-                }),
-                wasmparser::Operator::I32Mul => expr_op(&mut stack, |lhs, rhs| {
-                    i32::wrapping_mul(lhs as i32, rhs as i32) as i64
-                }),
-                wasmparser::Operator::I64Add => {
-                    expr_op(&mut stack, |lhs, rhs| lhs.wrapping_add(rhs))
-                }
-                wasmparser::Operator::I64Sub => {
-                    expr_op(&mut stack, |lhs, rhs| lhs.wrapping_sub(rhs))
-                }
-                wasmparser::Operator::I64Mul => {
-                    expr_op(&mut stack, |lhs, rhs| lhs.wrapping_mul(rhs))
-                }
+            let op = match reader.read()? {
+                wasmparser::Operator::I32Const { value } => Op::constant(value),
+                wasmparser::Operator::I64Const { value } => Op::constant(value),
+                wasmparser::Operator::F32Const { value } => Op::constant(F32::from(value.bits())),
+                wasmparser::Operator::F64Const { value } => Op::constant(F64::from(value.bits())),
+                wasmparser::Operator::GlobalGet { global_index } => Op::global(global_index),
+                wasmparser::Operator::RefNull { ty } => match ty {
+                    wasmparser::ValType::FuncRef => Op::constant(Value::from(FuncRef::null())),
+                    wasmparser::ValType::ExternRef => Op::constant(Value::from(ExternRef::null())),
+                    _ => return Err(CompilationError::NotSupportedOpcode),
+                },
+                wasmparser::Operator::RefFunc { function_index } => Op::funcref(function_index),
+                wasmparser::Operator::I32Add => Op::Binary(BinaryOp::I32Add),
+                wasmparser::Operator::I32Sub => Op::Binary(BinaryOp::I32Sub),
+                wasmparser::Operator::I32Mul => Op::Binary(BinaryOp::I32Mul),
+                wasmparser::Operator::I64Add => Op::Binary(BinaryOp::I64Add),
+                wasmparser::Operator::I64Sub => Op::Binary(BinaryOp::I64Sub),
+                wasmparser::Operator::I64Mul => Op::Binary(BinaryOp::I64Mul),
                 wasmparser::Operator::End => break,
-                op => panic!("encountered invalid Wasm const expression operator: {op:?}"),
+                _ => return Err(CompilationError::NotSupportedOpcode),
             };
+            height = match op {
+                // a binary operator consumes two values and produces one
+                Op::Binary(_) => {
+                    height
+                        .checked_sub(2)
+                        .ok_or(CompilationError::ConstEvaluationFailed)?
+                        + 1
+                }
+                _ => height + 1,
+            };
+            ops.push(op);
         }
-        reader
-            .ensure_end()
-            .expect("due to Wasm validation, this is guaranteed to succeed");
-        let op = stack
-            .pop()
-            .expect("due to Wasm validation must have one operator on the stack");
-        assert!(
-            stack.is_empty(),
-            "due to Wasm validation operator stack must be empty now"
-        );
-        Self { op }
+        reader.ensure_end()?;
+        if height != 1 {
+            return Err(CompilationError::ConstEvaluationFailed);
+        }
+        Ok(Self { ops })
     }
 
     /// Create a new `ref.func x` [`CompiledExpr`].
@@ -356,26 +248,27 @@ impl CompiledExpr {
     ///
     /// Required for setting up table elements.
     pub fn new_funcref(function_index: u32) -> Self {
-        Self {
-            op: Op::FuncRef(FuncRefOp { function_index }),
-        }
+        Self::from_op(Op::FuncRef(function_index))
     }
 
     /// Returns `Some(index)` if the [`CompiledExpr`] is a `funcref(index)`.
     ///
     /// Otherwise returns `None`.
     pub fn funcref(&self) -> Option<FuncIdx> {
-        if let Op::FuncRef(op) = &self.op {
-            return Some(FuncIdx::from(op.function_index));
+        match self.ops.as_slice() {
+            [Op::FuncRef(function_index)] => Some(FuncIdx::from(*function_index)),
+            _ => None,
         }
-        None
     }
 
+    /// Returns `Some(index)` if the [`CompiledExpr`] is a `global.get index`.
+    ///
+    /// Otherwise returns `None`.
     pub fn global(&self) -> Option<GlobalIdx> {
-        if let Op::Global(op) = &self.op {
-            return Some(GlobalIdx::from(op.global_index));
+        match self.ops.as_slice() {
+            [Op::Global(global_index)] => Some(GlobalIdx::from(*global_index)),
+            _ => None,
         }
-        None
     }
 
     /// Evaluates the [`CompiledExpr`] in a constant evaluation context.
@@ -431,6 +324,7 @@ impl CompiledExpr {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec::Vec;
 
     // A tiny evaluation context for tests.
     struct TestCtx {
@@ -475,6 +369,14 @@ mod tests {
         x.to_bits() as i64
     }
 
+    fn parse_const_expr(bytes: &[u8]) -> ConstExpr<'_> {
+        ConstExpr::new(bytes, 0)
+    }
+
+    fn compile(bytes: &[u8]) -> CompiledExpr {
+        CompiledExpr::new(parse_const_expr(bytes)).unwrap()
+    }
+
     #[test]
     fn empty_eval_context_always_none() {
         let ctx = EmptyEvalContext;
@@ -485,55 +387,34 @@ mod tests {
     }
 
     #[test]
-    fn constop_eval_returns_value() {
-        let ctx = EmptyEvalContext;
-        let op = ConstOp { value: 42 };
-        assert_eq!(op.eval(&ctx), Some(42));
-    }
-
-    #[test]
     fn op_constant_encodes_i32_i64() {
-        let ctx = EmptyEvalContext;
-
-        let op_i32 = Op::constant(Value::I32(-7));
-        assert_eq!(op_i32.eval(&ctx), Some(-7));
-
-        let op_i64 = Op::constant(Value::I64(-9));
-        assert_eq!(op_i64.eval(&ctx), Some(-9));
+        assert_eq!(Op::constant(Value::I32(-7)), Op::Const(-7));
+        assert_eq!(Op::constant(Value::I64(-9)), Op::Const(-9));
     }
 
     #[test]
     fn op_constant_encodes_f32_f64_bits() {
-        let ctx = EmptyEvalContext;
-
         // Use raw bit patterns that are stable.
         let f32v = f32::from_bits(0x7FC0_0001); // a NaN payload
         let f64v = f64::from_bits(0x7FF8_0000_0000_0001); // a NaN payload
 
         let op_f32 = Op::constant(Value::F32(F32::from(f32v.to_bits())));
-        assert_eq!(op_f32.eval(&ctx), Some(bits_f32(f32v)));
+        assert_eq!(op_f32, Op::Const(bits_f32(f32v)));
 
         let op_f64 = Op::constant(Value::F64(F64::from(f64v.to_bits())));
-        assert_eq!(op_f64.eval(&ctx), Some(bits_f64(f64v)));
+        assert_eq!(op_f64, Op::Const(bits_f64(f64v)));
     }
 
     #[test]
     fn op_constant_encodes_funcref_externref_ids() {
-        let ctx = EmptyEvalContext;
-
-        // This assumes your FuncRef/ExternRef are tuple structs with .0 as shown in your code.
         let fr = FuncRef(123);
         let er = FuncRef(456);
-
-        let op_fr = Op::constant(Value::FuncRef(fr));
-        assert_eq!(op_fr.eval(&ctx), Some(123));
-
-        let op_er = Op::constant(Value::ExternRef(er));
-        assert_eq!(op_er.eval(&ctx), Some(456));
+        assert_eq!(Op::constant(Value::FuncRef(fr)), Op::Const(123));
+        assert_eq!(Op::constant(Value::ExternRef(er)), Op::Const(456));
     }
 
     #[test]
-    fn globalop_maps_value_kinds_correctly() {
+    fn global_op_maps_value_kinds_correctly() {
         let nan32 = f32::from_bits(0x7FC0_0001);
         let nan64 = f64::from_bits(0x7FF8_0000_0000_0001);
 
@@ -546,53 +427,39 @@ mod tests {
             Some(Value::ExternRef(FuncRef(9))),
             None,
         ]);
+        let global = |index| CompiledExpr::from_op(Op::global(index));
 
-        assert_eq!(GlobalOp { global_index: 0 }.eval(&ctx), Some(-1));
-        assert_eq!(GlobalOp { global_index: 1 }.eval(&ctx), Some(-2));
-        assert_eq!(
-            GlobalOp { global_index: 2 }.eval(&ctx),
-            Some(bits_f32(nan32))
-        );
-        assert_eq!(
-            GlobalOp { global_index: 3 }.eval(&ctx),
-            Some(bits_f64(nan64))
-        );
-        assert_eq!(GlobalOp { global_index: 4 }.eval(&ctx), Some(7));
-        assert_eq!(GlobalOp { global_index: 5 }.eval(&ctx), Some(9));
+        assert_eq!(global(0).eval(&ctx), Some(-1));
+        assert_eq!(global(1).eval(&ctx), Some(-2));
+        assert_eq!(global(2).eval(&ctx), Some(nan32.to_bits() as u64 as i64));
+        assert_eq!(global(3).eval(&ctx), Some(bits_f64(nan64)));
+        assert_eq!(global(4).eval(&ctx), Some(7));
+        assert_eq!(global(5).eval(&ctx), Some(9));
 
         // None from context -> None from eval.
-        assert_eq!(GlobalOp { global_index: 6 }.eval(&ctx), None);
+        assert_eq!(global(6).eval(&ctx), None);
 
         // Out of range -> None
-        assert_eq!(GlobalOp { global_index: 999 }.eval(&ctx), None);
+        assert_eq!(global(999).eval(&ctx), None);
     }
 
     #[test]
-    fn funcrefop_reads_from_context() {
+    fn funcref_op_reads_from_context() {
         let ctx = TestCtx::new().with_funcs(alloc::vec![Some(FuncRef(1)), None, Some(FuncRef(3)),]);
+        let funcref = |index| CompiledExpr::new_funcref(index);
 
-        assert_eq!(FuncRefOp { function_index: 0 }.eval(&ctx), Some(1));
-        assert_eq!(FuncRefOp { function_index: 1 }.eval(&ctx), None);
-        assert_eq!(FuncRefOp { function_index: 2 }.eval(&ctx), Some(3));
+        assert_eq!(funcref(0).eval(&ctx), Some(1));
+        assert_eq!(funcref(1).eval(&ctx), None);
+        assert_eq!(funcref(2).eval(&ctx), Some(3));
 
         // Out of range -> None
-        assert_eq!(
-            FuncRefOp {
-                function_index: 999
-            }
-            .eval(&ctx),
-            None
-        );
+        assert_eq!(funcref(999).eval(&ctx), None);
     }
 
     #[test]
-    fn expr_op_combines_operands_and_propagates_none() {
+    fn binary_op_combines_operands_and_propagates_none() {
         // expr: global(0) + const(5)
-        let expr = Op::expr(|ctx: &dyn EvalContext| {
-            let a = Op::global(0).eval(ctx)?;
-            let b = Op::constant(Value::I32(5)).eval(ctx)?;
-            Some(i32::wrapping_add(a as i32, b as i32) as i64)
-        });
+        let expr = compile(&[0x23, 0x00, 0x41, 0x05, 0x6a, 0x0b]);
 
         let ctx_some = TestCtx::new().with_globals(alloc::vec![Some(Value::I32(10))]);
         assert_eq!(expr.eval(&ctx_some), Some(15));
@@ -619,15 +486,20 @@ mod tests {
         assert_eq!(e_fr.funcref(), Some(FuncIdx::from(42u32)));
         assert_eq!(e_fr.global(), None);
 
-        let e_g = CompiledExpr { op: Op::global(7) };
+        let e_g = CompiledExpr::from_op(Op::global(7));
         assert_eq!(e_g.global(), Some(GlobalIdx::from(7u32)));
         assert_eq!(e_g.funcref(), None);
+
+        // a compound expression is neither, even if it ends in `ref.func`/`global.get`
+        let compound = compile(&[0x41, 0x01, 0x23, 0x00, 0x6a, 0x0b]);
+        assert_eq!(compound.funcref(), None);
+        assert_eq!(compound.global(), None);
     }
 
     #[test]
     fn eval_with_context_reads_globals_and_funcs() {
-        let e_global = CompiledExpr { op: Op::global(0) };
-        let e_func = CompiledExpr { op: Op::funcref(1) };
+        let e_global = CompiledExpr::from_op(Op::global(0));
+        let e_func = CompiledExpr::from_op(Op::funcref(1));
 
         let g = |idx: u32| match idx {
             0 => Some(Value::I64(123)),
@@ -647,33 +519,9 @@ mod tests {
     }
 
     #[test]
-    fn op_clone_works_for_non_expr_variants() {
-        let c = Op::constant(Value::I64(1));
-        let g = Op::global(2);
-        let f = Op::funcref(3);
-
-        // Should not panic:
-        let _ = c.clone();
-        let _ = g.clone();
-        let _ = f.clone();
-    }
-
-    #[test]
-    #[should_panic(expected = "cloning of expr is not possible")]
-    fn op_clone_panics_for_expr_variant() {
-        let e = Op::expr(|_| Some(0));
-        let _ = e.clone();
-    }
-
-    fn parse_const_expr(bytes: &[u8]) -> ConstExpr<'_> {
-        ConstExpr::new(bytes, 0)
-    }
-
-    #[test]
     fn compiledexpr_new_i32_const() {
         // i32.const 7; end
-        let expr = parse_const_expr(&[0x41, 0x07, 0x0b]);
-        let c = CompiledExpr::new(expr);
+        let c = compile(&[0x41, 0x07, 0x0b]);
         assert_eq!(c.eval_const(), Some(7));
     }
 
@@ -681,21 +529,39 @@ mod tests {
     fn compiledexpr_new_i64_const() {
         // i64.const -1; end
         // signed LEB128 for -1 is 0x7f
-        let expr = parse_const_expr(&[0x42, 0x7f, 0x0b]);
-        let c = CompiledExpr::new(expr);
+        let c = compile(&[0x42, 0x7f, 0x0b]);
         assert_eq!(c.eval_const(), Some(-1));
+    }
+
+    #[test]
+    fn compiledexpr_new_f32_f64_const() {
+        // f32.const 1.0; end
+        let c = compile(&[0x43, 0x00, 0x00, 0x80, 0x3f, 0x0b]);
+        assert_eq!(c.eval_const(), Some(bits_f32(1.0)));
+        // f64.const 1.0; end
+        let c = compile(&[0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, 0x0b]);
+        assert_eq!(c.eval_const(), Some(bits_f64(1.0)));
+    }
+
+    #[test]
+    fn compiledexpr_new_ref_null() {
+        // ref.null func; end
+        let c = compile(&[0xd0, 0x70, 0x0b]);
+        assert_eq!(c.eval_const(), Some(FuncRef::null().0 as i64));
+        // ref.null extern; end
+        let c = compile(&[0xd0, 0x6f, 0x0b]);
+        assert_eq!(c.eval_const(), Some(ExternRef::null().0 as i64));
     }
 
     #[test]
     fn compiledexpr_new_i32_add_wraps() {
         // i32.const 0x7fffffff; i32.const 1; i32.add; end
-        let expr = parse_const_expr(&[
+        let c = compile(&[
             0x41, 0xff, 0xff, 0xff, 0xff, 0x07, // 2147483647
             0x41, 0x01, // 1
             0x6a, // i32.add
             0x0b, // end
         ]);
-        let c = CompiledExpr::new(expr);
         assert_eq!(c.eval_const(), Some(i32::MIN as i64));
     }
 
@@ -703,36 +569,44 @@ mod tests {
     fn compiledexpr_new_i32_sub_wraps() {
         // i32.const i32::MIN; i32.const 1; i32.sub; end
         // i32::MIN = -2147483648 -> signed LEB128: 0x80 0x80 0x80 0x80 0x78
-        let expr = parse_const_expr(&[
+        let c = compile(&[
             0x41, 0x80, 0x80, 0x80, 0x80, 0x78, // -2147483648
             0x41, 0x01, // 1
             0x6b, // i32.sub
             0x0b,
         ]);
-        let c = CompiledExpr::new(expr);
         assert_eq!(c.eval_const(), Some(i32::MAX as i64));
     }
 
     #[test]
-    fn compiledexpr_new_i64_mul_wraps() {
-        // i64.const i64::MAX; i64.const 2; i64.mul; end
-        // i64::MAX LEB128 is a bit long; easiest is:
-        // i64.const -1; i64.const 2; i64.mul => -2
-        let expr = parse_const_expr(&[
-            0x42, 0x7f, // i64.const -1
-            0x42, 0x02, // i64.const 2
-            0x7e, // i64.mul
+    fn compiledexpr_new_i32_mul_wraps() {
+        // i32.const 0x40000000; i32.const 4; i32.mul; end
+        let c = compile(&[
+            0x41, 0x80, 0x80, 0x80, 0x80, 0x04, // 0x40000000
+            0x41, 0x04, // 4
+            0x6c, // i32.mul
             0x0b,
         ]);
-        let c = CompiledExpr::new(expr);
+        assert_eq!(c.eval_const(), Some(0));
+    }
+
+    #[test]
+    fn compiledexpr_new_i64_add_sub_mul_wrap() {
+        // i64.const -1; i64.const 2; i64.mul => -2
+        let c = compile(&[0x42, 0x7f, 0x42, 0x02, 0x7e, 0x0b]);
         assert_eq!(c.eval_const(), Some(-2));
+        // i64.const -1; i64.const 2; i64.add => 1
+        let c = compile(&[0x42, 0x7f, 0x42, 0x02, 0x7c, 0x0b]);
+        assert_eq!(c.eval_const(), Some(1));
+        // i64.const -1; i64.const 2; i64.sub => -3
+        let c = compile(&[0x42, 0x7f, 0x42, 0x02, 0x7d, 0x0b]);
+        assert_eq!(c.eval_const(), Some(-3));
     }
 
     #[test]
     fn compiledexpr_new_global_get_uses_context() {
         // global.get 0; end
-        let expr = parse_const_expr(&[0x23, 0x00, 0x0b]);
-        let c = CompiledExpr::new(expr);
+        let c = compile(&[0x23, 0x00, 0x0b]);
 
         let ctx = TestCtx::new().with_globals(alloc::vec![Some(Value::I32(99))]);
         assert_eq!(c.eval(&ctx), Some(99));
@@ -744,21 +618,11 @@ mod tests {
     #[test]
     fn compiledexpr_new_ref_func_uses_context() {
         // ref.func 2; end
-        let expr = parse_const_expr(&[0xd2, 0x02, 0x0b]);
-        let c = CompiledExpr::new(expr);
+        let c = compile(&[0xd2, 0x02, 0x0b]);
+        assert_eq!(c.funcref(), Some(2));
 
         let ctx = TestCtx::new().with_funcs(alloc::vec![None, None, Some(FuncRef(555))]);
         assert_eq!(c.eval(&ctx), Some(555));
-    }
-
-    #[test]
-    fn compiledexpr_new_i32_add_mixed_const_and_global() {
-        // global.get 0; i32.const 5; i32.add; end
-        let expr = parse_const_expr(&[0x23, 0x00, 0x41, 0x05, 0x6a, 0x0b]);
-        let c = CompiledExpr::new(expr);
-
-        let ctx = TestCtx::new().with_globals(alloc::vec![Some(Value::I32(10))]);
-        assert_eq!(c.eval(&ctx), Some(15));
     }
 
     #[test]
@@ -766,10 +630,9 @@ mod tests {
         // global.get 0; ref.func 1; i32.add; end
         //
         // This isn't a valid *typed* Wasm const expr in a real module (i32.add expects i32),
-        // but your translator assumes validation already ran. This test ensures the
+        // but the translator assumes validation already ran. This test ensures the
         // translation/eval plumbing works for mixed operands (it will treat funcref as i64).
-        let expr = parse_const_expr(&[0x23, 0x00, 0xd2, 0x01, 0x6a, 0x0b]);
-        let c = CompiledExpr::new(expr);
+        let c = compile(&[0x23, 0x00, 0xd2, 0x01, 0x6a, 0x0b]);
 
         let ctx = TestCtx::new()
             .with_globals(alloc::vec![Some(Value::I32(10))])
@@ -780,10 +643,70 @@ mod tests {
 
     #[test]
     fn compiledexpr_eval_const_returns_none_for_global_or_funcref() {
-        let e_g = CompiledExpr { op: Op::global(0) };
-        let e_f = CompiledExpr { op: Op::funcref(0) };
+        let e_g = CompiledExpr::from_op(Op::global(0));
+        let e_f = CompiledExpr::from_op(Op::funcref(0));
 
         assert_eq!(e_g.eval_const(), None);
         assert_eq!(e_f.eval_const(), None);
+    }
+
+    #[test]
+    fn compiledexpr_new_rejects_unbalanced_operators() {
+        // two values left on the stack: i32.const 1; i32.const 2; end
+        let err = CompiledExpr::new(parse_const_expr(&[0x41, 0x01, 0x41, 0x02, 0x0b])).unwrap_err();
+        assert!(matches!(err, CompilationError::ConstEvaluationFailed));
+        // a binary operator without operands: i32.add; end
+        let err = CompiledExpr::new(parse_const_expr(&[0x6a, 0x0b])).unwrap_err();
+        assert!(matches!(err, CompilationError::ConstEvaluationFailed));
+        // a binary operator with one operand: i32.const 1; i32.add; end
+        let err = CompiledExpr::new(parse_const_expr(&[0x41, 0x01, 0x6a, 0x0b])).unwrap_err();
+        assert!(matches!(err, CompilationError::ConstEvaluationFailed));
+        // no value at all: end
+        let err = CompiledExpr::new(parse_const_expr(&[0x0b])).unwrap_err();
+        assert!(matches!(err, CompilationError::ConstEvaluationFailed));
+    }
+
+    #[test]
+    fn compiledexpr_new_rejects_operators_outside_the_constant_subset() {
+        // i32.const 1; i32.eqz; end
+        let err = CompiledExpr::new(parse_const_expr(&[0x41, 0x01, 0x45, 0x0b])).unwrap_err();
+        assert!(matches!(err, CompilationError::NotSupportedOpcode));
+        // ref.null with a non-reference heap type
+        let err = CompiledExpr::new(parse_const_expr(&[0xd0, 0x7f, 0x0b])).unwrap_err();
+        assert!(matches!(
+            err,
+            CompilationError::NotSupportedOpcode | CompilationError::MalformedWasmBinary(_)
+        ));
+        // a truncated expression
+        let err = CompiledExpr::new(parse_const_expr(&[0x41, 0x01])).unwrap_err();
+        assert!(matches!(err, CompilationError::MalformedWasmBinary(_)));
+    }
+
+    /// The regression for the nested-closure representation: a validated `extended-const`
+    /// expression may chain hundreds of thousands of operators, and translating, evaluating and
+    /// dropping it must not recurse.
+    #[test]
+    fn long_operator_chain_does_not_recurse() {
+        const OPERATORS: usize = 300_000;
+        // i32.const 0; (i32.const 1; i32.add) x OPERATORS; end
+        let mut bytes = alloc::vec![0x41, 0x00];
+        for _ in 0..OPERATORS {
+            bytes.extend_from_slice(&[0x41, 0x01, 0x6a]);
+        }
+        bytes.push(0x0b);
+        let expr = compile(&bytes);
+        assert_eq!(expr.eval_const(), Some(OPERATORS as i64));
+        assert_eq!(expr.funcref(), None);
+        drop(expr);
+
+        // a chain that builds up a deep operand stack before folding it
+        let mut bytes = alloc::vec![];
+        for _ in 0..=OPERATORS {
+            bytes.extend_from_slice(&[0x42, 0x01]); // i64.const 1
+        }
+        bytes.extend(core::iter::repeat_n(0x7c, OPERATORS)); // i64.add
+        bytes.push(0x0b);
+        let expr = compile(&bytes);
+        assert_eq!(expr.eval_const(), Some(OPERATORS as i64 + 1));
     }
 }

--- a/src/compiler/config.rs
+++ b/src/compiler/config.rs
@@ -126,6 +126,10 @@ impl CompilationConfig {
     /// Returns `true` if this config charges the same fuel on the rwasm and Wasmtime strategies.
     ///
     /// See [`CompilationConfig::default_strategy_compatible`] for which flags diverge.
+    /// [`crate::StrategyDefinition::new`], [`crate::StrategyDefinition::new_as_wasmtime`] and
+    /// [`crate::for_each_strategy`] reject a config for which this returns `false`; only
+    /// [`crate::StrategyDefinition::new_as_rwasm`] and [`crate::RwasmModule::compile`] accept the
+    /// rwasm-only injections, since the rwasm VM is the one strategy that implements them.
     pub fn is_strategy_compatible(&self) -> bool {
         !self.consume_fuel_for_bulk_ops && !self.consume_fuel_for_params_and_locals
     }

--- a/src/compiler/config.rs
+++ b/src/compiler/config.rs
@@ -68,9 +68,10 @@ pub struct CompilationConfig {
     /// The maximum number of memory pages that can be allocated by the module.
     pub max_allowed_memory_pages: u32,
     /// Maximum entries in the Wasm function-type section, including duplicates (default: 4096).
-    /// Checked before type validation allocates memory or signature deduplication runs.
-    /// Increasing this limit permits more quadratic compilation work and should be coordinated
-    /// with the host's compilation budget. It does not change emitted bytecode.
+    /// Checked before type validation allocates memory for the declared count. Every declared
+    /// type costs constant work in the compiler, so raising this limit scales compile time
+    /// linearly; coordinate it with the host's compilation budget. It does not change emitted
+    /// bytecode.
     pub max_allowed_function_types: u32,
 }
 

--- a/src/compiler/error.rs
+++ b/src/compiler/error.rs
@@ -30,6 +30,10 @@ pub enum CompilationError {
         count: u32,
         limit: u32,
     },
+    /// The config enables fuel injections that only the rwasm strategy implements, so the same
+    /// module would burn different fuel on the two strategies; see
+    /// [`crate::CompilationConfig::default_strategy_compatible`].
+    StrategyIncompatibleConfig,
     /// A table declares more initial elements than [`crate::N_MAX_TABLE_SIZE`] permits.
     TableSizeExceedsLimit {
         size: u32,
@@ -89,6 +93,11 @@ impl core::fmt::Display for CompilationError {
                     "function type count {count} exceeds compilation limit {limit}"
                 )
             }
+            CompilationError::StrategyIncompatibleConfig => write!(
+                f,
+                "compilation config enables rwasm-only fuel injections; use \
+                 CompilationConfig::default_strategy_compatible()"
+            ),
             CompilationError::TableSizeExceedsLimit { size, limit } => {
                 write!(f, "table size {size} exceeds compilation limit {limit}")
             }

--- a/src/compiler/error.rs
+++ b/src/compiler/error.rs
@@ -30,6 +30,11 @@ pub enum CompilationError {
         count: u32,
         limit: u32,
     },
+    /// A table declares more initial elements than [`crate::N_MAX_TABLE_SIZE`] permits.
+    TableSizeExceedsLimit {
+        size: u32,
+        limit: u32,
+    },
     /// Wasmtime rejected a binary that passed rwasm validation.
     #[cfg(feature = "wasmtime")]
     WasmtimeCompilationFailed(wasmtime::Error),
@@ -83,6 +88,9 @@ impl core::fmt::Display for CompilationError {
                     f,
                     "function type count {count} exceeds compilation limit {limit}"
                 )
+            }
+            CompilationError::TableSizeExceedsLimit { size, limit } => {
+                write!(f, "table size {size} exceeds compilation limit {limit}")
             }
             #[cfg(feature = "wasmtime")]
             CompilationError::WasmtimeCompilationFailed(err) => {

--- a/src/compiler/error.rs
+++ b/src/compiler/error.rs
@@ -26,7 +26,13 @@ pub enum CompilationError {
     MemoryOutOfBounds,
     TableOutOfBounds,
     StartSectionsAreNotAllowed,
-    TooManyFunctionTypes { count: u32, limit: u32 },
+    TooManyFunctionTypes {
+        count: u32,
+        limit: u32,
+    },
+    /// Wasmtime rejected a binary that passed rwasm validation.
+    #[cfg(feature = "wasmtime")]
+    WasmtimeCompilationFailed(wasmtime::Error),
 }
 
 impl core::error::Error for CompilationError {}
@@ -77,6 +83,10 @@ impl core::fmt::Display for CompilationError {
                     f,
                     "function type count {count} exceeds compilation limit {limit}"
                 )
+            }
+            #[cfg(feature = "wasmtime")]
+            CompilationError::WasmtimeCompilationFailed(err) => {
+                write!(f, "wasmtime compilation failed ({err})")
             }
         }
     }

--- a/src/compiler/func_type_registry.rs
+++ b/src/compiler/func_type_registry.rs
@@ -1,5 +1,6 @@
 use crate::{CompilationError, FuncTypeIdx, SignatureIdx};
 use alloc::vec::Vec;
+use hashbrown::HashMap;
 use wasmparser::{BlockType, FuncType, ValType};
 
 #[derive(Default, Debug)]
@@ -7,6 +8,13 @@ pub struct FuncTypeRegistry {
     original_func_types: Vec<FuncType>,
     func_types: Vec<FuncType>,
     original_signatures: Vec<SignatureIdx>,
+    /// Canonical signature index of every distinct original function type registered so far.
+    ///
+    /// Deduplication is one hash lookup per declared type. A linear scan over the registered
+    /// types would make the type section quadratic to process, and compilation runs before any
+    /// fuel is charged, so an adversarial module with many distinct types could burn seconds of
+    /// validator CPU.
+    signatures_by_type: HashMap<FuncType, SignatureIdx>,
 }
 
 impl FuncTypeRegistry {
@@ -56,17 +64,16 @@ impl FuncTypeRegistry {
                 _ => adjusted_result.push(*x),
             }
         }
-        let dedup_type_position = self
-            .original_func_types
-            .iter()
-            .position(|v| v == &func_type);
         let next_func_type_index = self.original_func_types.len();
+        // the first occurrence of a signature becomes its canonical index
+        let signature_index = *self
+            .signatures_by_type
+            .entry(func_type.clone())
+            .or_insert(next_func_type_index as SignatureIdx);
         self.original_func_types.push(func_type);
         let adjusted_func_type = FuncType::new(adjusted_params, adjusted_result);
         self.func_types.push(adjusted_func_type);
-        let dedup_type_position = dedup_type_position.unwrap_or(next_func_type_index);
-        self.original_signatures
-            .push(dedup_type_position as SignatureIdx);
+        self.original_signatures.push(signature_index);
         Ok(next_func_type_index as FuncTypeIdx)
     }
 
@@ -158,5 +165,30 @@ mod tests {
         assert_eq!(registry.original_func_types.len(), 3);
         assert_eq!(registry.func_types.len(), 3);
         assert_eq!(registry.original_signatures.len(), 3);
+    }
+
+    #[test]
+    fn deduplicates_interleaved_signatures_to_their_first_occurrence() {
+        let distinct = |n: u32| -> FuncType {
+            let params: Vec<ValType> = (0..8)
+                .map(|bit| if n & (1 << bit) == 0 { I32 } else { I64 })
+                .collect();
+            FuncType::new(params, [])
+        };
+        let mut types = Vec::new();
+        for n in 0..64 {
+            types.push(distinct(n));
+            // every type is declared a second time right after a different one
+            types.push(distinct(n / 2));
+        }
+        let registry = FuncTypeRegistry::new(types.clone()).unwrap();
+        for (index, func_type) in types.iter().enumerate() {
+            let first = types.iter().position(|v| v == func_type).unwrap();
+            assert_eq!(
+                registry.resolve_func_type_signature(index as FuncTypeIdx),
+                first as SignatureIdx
+            );
+        }
+        assert_eq!(registry.signatures_by_type.len(), 64);
     }
 }

--- a/src/compiler/locals_registry.rs
+++ b/src/compiler/locals_registry.rs
@@ -1,22 +1,13 @@
-/// A registry where local variables of a function are registered and resolved.
+/// Counts the local variables of the function being translated.
 ///
 /// # Note
 ///
-/// Note that in WebAssembly function parameters are also local variables.
+/// In WebAssembly function parameters are also local variables.
 ///
-/// The local registry efficiently registers and resolves local variables.
-/// The problem is that the Wasm specification allows encoding up to `u32::MAX`
-/// local variables in a small and constant space via the binary encoding.
-/// Therefore, we need a way to efficiently cope with this worst-case scenario
-///  to protect the `rwasm` interpreter against exploitation.
-///
-/// This implementation allows accessing local variables in this worst-case
-/// scenario with the worst time complexity of O(log n) and space requirement
-/// of O(m + n) where n is the number of registered groups of local variables
-/// and m is the number of actually used local variables.
-///
-/// Besides that, local variable usages are cached to further minimize potential
-/// exploitation impact.
+/// The Wasm binary encoding declares up to `u32::MAX` locals in a few bytes, so the registry only
+/// tracks their number; each local's type lives on the translator's operand-type stack
+/// (`TypeStack`), which resolves the slot depth of a local access in O(1) without a per-usage
+/// cache.
 #[derive(Debug, Default)]
 pub struct LocalsRegistry {
     /// The number of registered local variables.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -14,6 +14,7 @@ mod parser;
 mod segment_builder;
 mod snippets;
 mod translator;
+mod type_stack;
 mod utils;
 mod value_stack;
 

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -777,18 +777,18 @@ impl ModuleParser {
                             element_offset,
                             table_idx,
                             element_items_vec,
-                        );
+                        )?;
                 }
                 ElementKind::Passive => self
                     .allocations
                     .translation
                     .segment_builder
-                    .add_passive_elements(element_segment_idx, element_items_vec),
+                    .add_passive_elements(element_segment_idx, element_items_vec)?,
                 ElementKind::Declared => self
                     .allocations
                     .translation
                     .segment_builder
-                    .add_passive_elements(element_segment_idx, []),
+                    .add_passive_elements(element_segment_idx, [])?,
             };
         }
         Ok(())
@@ -839,13 +839,13 @@ impl ModuleParser {
                     self.allocations
                         .translation
                         .segment_builder
-                        .add_active_memory(data_segment_idx, data_offset, data.data);
+                        .add_active_memory(data_segment_idx, data_offset, data.data)?;
                 }
                 DataKind::Passive => self
                     .allocations
                     .translation
                     .segment_builder
-                    .add_passive_memory(data_segment_idx, data.data),
+                    .add_passive_memory(data_segment_idx, data.data)?,
             };
         }
         Ok(())

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -672,7 +672,7 @@ impl ModuleParser {
         self.validator.global_section(&section)?;
         for global in section.into_iter() {
             let global = global?;
-            let init_expr = CompiledExpr::new(global.init_expr);
+            let init_expr = CompiledExpr::new(global.init_expr)?;
             let default_value = self.eval_const(init_expr)?;
             let global_variable = GlobalVariable::new(global.ty, default_value);
             let global_idx = GlobalIdx::from(self.allocations.translation.globals.len() as u32);
@@ -745,7 +745,7 @@ impl ModuleParser {
                 ElementItems::Expressions(section) => section
                     .into_iter()
                     .map(|v| {
-                        let compiled_expr = CompiledExpr::new(v?);
+                        let compiled_expr = CompiledExpr::new(v?)?;
                         compiled_expr
                             .funcref()
                             .map(|v| v + 1)
@@ -764,7 +764,7 @@ impl ModuleParser {
                     table_index,
                     offset_expr,
                 } => {
-                    let compiled_expr = CompiledExpr::new(offset_expr);
+                    let compiled_expr = CompiledExpr::new(offset_expr)?;
                     // We can fail-fast here because we already that know that there an overflow
                     let element_offset = u32::try_from(self.eval_const(compiled_expr)?)
                         .map_err(|_| CompilationError::TableOutOfBounds)?;
@@ -832,7 +832,7 @@ impl ModuleParser {
                     if memory_index != DEFAULT_MEMORY_INDEX {
                         return Err(CompilationError::NonDefaultMemoryIndex);
                     }
-                    let compiled_expr = CompiledExpr::new(offset_expr);
+                    let compiled_expr = CompiledExpr::new(offset_expr)?;
                     // We can fail-fast here because we already that know that there an overflow
                     let data_offset = u32::try_from(self.eval_const(compiled_expr)?)
                         .map_err(|_| CompilationError::MemoryOutOfBounds)?;

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -425,8 +425,7 @@ impl ModuleParser {
     ///
     /// If the configured type count limit is exceeded or an unsupported function type is encountered.
     fn process_types(&mut self, section: TypeSectionReader) -> Result<(), CompilationError> {
-        // Validation reserves storage for the declared count; bound it before that allocation
-        // and before the registry's quadratic signature-deduplication scan.
+        // Validation reserves storage for the declared count; bound it before that allocation.
         if section.count() > self.config.max_allowed_function_types {
             return Err(CompilationError::TooManyFunctionTypes {
                 count: section.count(),

--- a/src/compiler/segment_builder.rs
+++ b/src/compiler/segment_builder.rs
@@ -48,9 +48,10 @@ impl SegmentBuilder {
     ) -> Result<(), CompilationError> {
         let global_type = global_variable.global_type.content_type;
         match global_type {
+            // a 32-bit global carries its initializer in the low limb of the `i64`
             ValType::I32 | ValType::F32 => self
                 .entrypoint_bytecode
-                .op_i32_const(global_variable.default_value),
+                .op_i32_const(global_variable.default_value as i32),
             ValType::I64 | ValType::F64 => {
                 let (lower, upper) = global_variable.default_value.split_into_i32_tuple();
                 self.entrypoint_bytecode.op_i32_const(lower);
@@ -128,7 +129,26 @@ impl SegmentBuilder {
         Ok(())
     }
 
-    pub fn add_active_memory(&mut self, segment_idx: DataSegmentIdx, offset: u32, bytes: &[u8]) {
+    /// Converts a data-section offset or length into the `u32` the bytecode carries.
+    ///
+    /// The data section is bounded by the module size, so an overflow is unreachable in practice;
+    /// it is reported as an error rather than truncated because the value ends up in consensus
+    /// bytecode.
+    fn data_section_u32(value: usize) -> Result<u32, CompilationError> {
+        u32::try_from(value).map_err(|_| CompilationError::MaxReadonlyDataReached)
+    }
+
+    /// Converts an element-section offset or length into the `u32` the bytecode carries.
+    fn elem_section_u32(value: usize) -> Result<u32, CompilationError> {
+        u32::try_from(value).map_err(|_| CompilationError::TableOutOfBounds)
+    }
+
+    pub fn add_active_memory(
+        &mut self,
+        segment_idx: DataSegmentIdx,
+        offset: u32,
+        bytes: &[u8],
+    ) -> Result<(), CompilationError> {
         // don't allow growing default memory if there are no enough pages allocated
         // `None` means the page arithmetic overflowed `u32`, which is itself proof that the
         // segment is out of range, so the caller below must treat it as an overflow
@@ -140,8 +160,8 @@ impl SegmentBuilder {
             Some(max_affected_page > self.total_allocated_pages)
         };
         // expand default memory
-        let data_offset = self.global_memory_section.len();
-        let data_length = bytes.len();
+        let data_offset = Self::data_section_u32(self.global_memory_section.len())?;
+        let data_length = Self::data_section_u32(bytes.len())?;
         self.global_memory_section.extend(bytes);
         // default memory is just a passive section with force memory init
         self.entrypoint_bytecode.op_i32_const(offset);
@@ -157,17 +177,23 @@ impl SegmentBuilder {
         self.entrypoint_bytecode.op_data_drop(segment_idx + 1);
         // store passive section info
         self.memory_sections
-            .insert(segment_idx, (offset, bytes.len() as u32));
+            .insert(segment_idx, (offset, data_length));
+        Ok(())
     }
 
-    pub fn add_passive_memory(&mut self, segment_idx: DataSegmentIdx, bytes: &[u8]) {
+    pub fn add_passive_memory(
+        &mut self,
+        segment_idx: DataSegmentIdx,
+        bytes: &[u8],
+    ) -> Result<(), CompilationError> {
         // expand default memory
-        let data_offset = self.global_memory_section.len() as u32;
-        let data_length = bytes.len() as u32;
+        let data_offset = Self::data_section_u32(self.global_memory_section.len())?;
+        let data_length = Self::data_section_u32(bytes.len())?;
         self.global_memory_section.extend(bytes);
         // store passive section info
         self.memory_sections
             .insert(segment_idx, (data_offset, data_length));
+        Ok(())
     }
 
     pub fn add_active_elements<T: IntoIterator<Item = u32>>(
@@ -176,11 +202,13 @@ impl SegmentBuilder {
         offset: u32,
         table_idx: TableIdx,
         elements: T,
-    ) {
+    ) -> Result<(), CompilationError> {
         // expand an element section (remember offset and length)
         let segment_offset = self.global_element_section.len();
         self.global_element_section.extend(elements);
-        let segment_length = self.global_element_section.len() - segment_offset;
+        let segment_length =
+            Self::elem_section_u32(self.global_element_section.len() - segment_offset)?;
+        let segment_offset = Self::elem_section_u32(segment_offset)?;
         // init table with these elements
         // TODO(dmitry123): "add stack height check"
         self.entrypoint_bytecode.op_i32_const(offset);
@@ -191,20 +219,24 @@ impl SegmentBuilder {
         self.entrypoint_bytecode.op_elem_drop(segment_idx + 1);
         // store active section info
         self.element_sections
-            .insert(segment_idx, (offset, segment_length as u32));
+            .insert(segment_idx, (offset, segment_length));
+        Ok(())
     }
 
     pub fn add_passive_elements<T: IntoIterator<Item = u32>>(
         &mut self,
         segment_idx: ElementSegmentIdx,
         elements: T,
-    ) {
+    ) -> Result<(), CompilationError> {
         // expand element section
-        let segment_offset = self.global_element_section.len() as u32;
+        let segment_offset = self.global_element_section.len();
         self.global_element_section.extend(elements);
-        let segment_length = self.global_element_section.len() as u32 - segment_offset;
+        let segment_length =
+            Self::elem_section_u32(self.global_element_section.len() - segment_offset)?;
+        let segment_offset = Self::elem_section_u32(segment_offset)?;
         // store passive section info
         self.element_sections
             .insert(segment_idx, (segment_offset, segment_length));
+        Ok(())
     }
 }

--- a/src/compiler/segment_builder.rs
+++ b/src/compiler/segment_builder.rs
@@ -1,7 +1,7 @@
 use crate::{
     instruction_set, CompilationError, DataSegmentIdx, ElementSegmentIdx, GlobalIdx,
     GlobalVariable, I64ValueSplit, InstructionSet, TableIdx, TrapCode, DEFAULT_MEMORY_INDEX,
-    NULL_FUNC_IDX, N_BYTES_PER_MEMORY_PAGE,
+    NULL_FUNC_IDX, N_BYTES_PER_MEMORY_PAGE, N_MAX_TABLE_SIZE,
 };
 use alloc::{vec, vec::Vec};
 use hashbrown::HashMap;
@@ -104,11 +104,21 @@ impl SegmentBuilder {
         Ok(())
     }
 
+    /// Max stack height: 2
     pub fn emit_table_segment(
         &mut self,
         table_index: TableIdx,
         table_type: &TableType,
     ) -> Result<(), CompilationError> {
+        // the runtime caps every table at `N_MAX_TABLE_SIZE` and the grow below discards its
+        // result, so a larger declared size would leave the rwasm VM running on an empty table
+        // while Wasmtime honours the declaration; reject it here so the module never compiles
+        if table_type.initial > N_MAX_TABLE_SIZE {
+            return Err(CompilationError::TableSizeExceedsLimit {
+                size: table_type.initial,
+                limit: N_MAX_TABLE_SIZE,
+            });
+        }
         // Wasm validation guarantees that the number of table segments can't exceed 100 items,
         // that is why there is no need to check for potential overflow
         self.entrypoint_bytecode.op_ref_func(NULL_FUNC_IDX);

--- a/src/compiler/translator.rs
+++ b/src/compiler/translator.rs
@@ -12,6 +12,7 @@ use crate::{
         locals_registry::LocalsRegistry,
         segment_builder::SegmentBuilder,
         snippets::{Snippet, SnippetCall},
+        type_stack::TypeStack,
         utils::RelativeDepth,
         value_stack::ValueStackHeight,
     },
@@ -49,12 +50,11 @@ pub struct FuncTranslatorAllocations {
     pub(crate) instruction_set: InstructionSet,
     /// Buffer for translating `br_table`.
     pub(crate) br_table_branches: InstructionSet,
-    /// A vector representing the types of values on a stack.
+    /// The emulated Wasm operand-type stack.
     ///
-    /// This field is used to track the `ValType` of elements in a stack-like structure.
-    /// It is defined with `pub(crate)` visibility, meaning that it is accessible
-    /// within the current crate but not outside it.
-    pub(crate) stack_types: Vec<ValType>,
+    /// Tracks the `ValType` of every operand together with the value-stack slot height of each
+    /// prefix, so that the slot depth of a local can be resolved without scanning the stack.
+    pub(crate) stack_types: TypeStack,
     /// Module builder for rWASM
     pub(crate) segment_builder: SegmentBuilder,
     /// A registry for func types
@@ -591,20 +591,10 @@ impl InstructionTranslator {
             .unwrap_or_else(|| panic!("cannot convert a local index into local depth: {local_idx}"))
     }
 
+    /// Returns the number of value-stack slots occupied by the top `local_depth` operands, which
+    /// is the depth the emitted `local.*` opcode addresses.
     fn get_expressed_depth(&self, local_depth: u32) -> u32 {
-        self.alloc
-            .stack_types
-            .iter()
-            .rev()
-            .take(local_depth as usize)
-            .map(|t| {
-                if t == &ValType::I64 || t == &ValType::F64 {
-                    2
-                } else {
-                    1
-                }
-            })
-            .sum()
+        self.alloc.stack_types.slot_depth(local_depth)
     }
 
     /// Adjusts the emulated value stack given the [`rwasm_legacy::FuncType`] of the call.

--- a/src/compiler/type_stack.rs
+++ b/src/compiler/type_stack.rs
@@ -1,0 +1,179 @@
+use alloc::vec::Vec;
+use core::ops::Index;
+use wasmparser::ValType;
+
+/// The emulated Wasm operand-type stack of the function being translated.
+///
+/// rwasm is a 32-bit slot machine: an `i64`/`f64` operand occupies two value-stack slots, every
+/// other type one. Translating `local.get`/`local.set`/`local.tee` needs the slot depth of a
+/// suffix of this stack, so next to the types it keeps an inclusive prefix sum of slot counts and
+/// answers that query in O(1). Summing the suffix on every access would make each local access
+/// linear in the current stack height and a function with many locals quadratic to compile, and
+/// compilation is not fuel-metered.
+#[derive(Debug, Default)]
+pub struct TypeStack {
+    types: Vec<ValType>,
+    /// `slots[i]` is the number of value-stack slots occupied by `types[..=i]`.
+    slots: Vec<u32>,
+}
+
+impl TypeStack {
+    /// Returns the number of value-stack slots a value of type `ty` occupies.
+    #[inline]
+    pub(crate) fn slots_of(ty: ValType) -> u32 {
+        match ty {
+            ValType::I64 | ValType::F64 => 2,
+            _ => 1,
+        }
+    }
+
+    /// Returns the number of types on the stack.
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        self.types.len()
+    }
+
+    /// Returns `true` if the stack holds no types.
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.types.is_empty()
+    }
+
+    /// Removes every type from the stack.
+    #[inline]
+    pub(crate) fn clear(&mut self) {
+        self.types.clear();
+        self.slots.clear();
+    }
+
+    /// Pushes `ty` on top of the stack.
+    #[inline]
+    pub(crate) fn push(&mut self, ty: ValType) {
+        let height = self.slot_height() + Self::slots_of(ty);
+        self.types.push(ty);
+        self.slots.push(height);
+    }
+
+    /// Pushes every type of `types` in order.
+    pub(crate) fn extend<'a>(&mut self, types: impl IntoIterator<Item = &'a ValType>) {
+        for ty in types {
+            self.push(*ty);
+        }
+    }
+
+    /// Pops the top type, or `None` if the stack is empty.
+    #[inline]
+    pub(crate) fn pop(&mut self) -> Option<ValType> {
+        self.slots.pop();
+        self.types.pop()
+    }
+
+    /// Returns the top type without removing it.
+    #[inline]
+    pub(crate) fn last(&self) -> Option<&ValType> {
+        self.types.last()
+    }
+
+    /// Returns the number of value-stack slots occupied by the whole stack.
+    #[inline]
+    pub(crate) fn slot_height(&self) -> u32 {
+        self.slots.last().copied().unwrap_or(0)
+    }
+
+    /// Returns the number of value-stack slots occupied by the top `depth` types.
+    ///
+    /// `depth` must not exceed [`TypeStack::len`]; a larger depth is clamped to the whole stack.
+    #[inline]
+    pub(crate) fn slot_depth(&self, depth: u32) -> u32 {
+        let below = self.types.len().saturating_sub(depth as usize);
+        let slots_below = below
+            .checked_sub(1)
+            .map(|index| self.slots[index])
+            .unwrap_or(0);
+        self.slot_height() - slots_below
+    }
+}
+
+impl Index<usize> for TypeStack {
+    type Output = ValType;
+
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.types[index]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The definition `slot_depth` must agree with: the sum over the top `depth` types.
+    fn naive_slot_depth(types: &[ValType], depth: u32) -> u32 {
+        types
+            .iter()
+            .rev()
+            .take(depth as usize)
+            .map(|ty| TypeStack::slots_of(*ty))
+            .sum()
+    }
+
+    #[test]
+    fn slot_depth_matches_the_suffix_sum_under_pushes_and_pops() {
+        let mut stack = TypeStack::default();
+        let mut reference = Vec::new();
+        // a fixed pseudo-random sequence of pushes and pops over every value type
+        let mut state = 0x9e37_79b9_u32;
+        for _ in 0..2_000 {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            if state.is_multiple_of(3) && !reference.is_empty() {
+                assert_eq!(stack.pop(), reference.pop());
+            } else {
+                let ty = match state % 7 {
+                    0 => ValType::I32,
+                    1 => ValType::I64,
+                    2 => ValType::F32,
+                    3 => ValType::F64,
+                    4 => ValType::FuncRef,
+                    5 => ValType::ExternRef,
+                    _ => ValType::I64,
+                };
+                stack.push(ty);
+                reference.push(ty);
+            }
+            assert_eq!(stack.len(), reference.len());
+            assert_eq!(stack.last(), reference.last());
+            assert_eq!(
+                stack.slot_height(),
+                naive_slot_depth(&reference, reference.len() as u32)
+            );
+            for depth in 0..=reference.len() as u32 {
+                assert_eq!(
+                    stack.slot_depth(depth),
+                    naive_slot_depth(&reference, depth),
+                    "depth {depth} of {reference:?}"
+                );
+            }
+        }
+        stack.clear();
+        assert!(stack.is_empty());
+        assert_eq!(stack.slot_height(), 0);
+        assert_eq!(stack.slot_depth(0), 0);
+    }
+
+    #[test]
+    fn extend_and_index_follow_the_pushed_order() {
+        let mut stack = TypeStack::default();
+        stack.extend(&[ValType::I32, ValType::I64, ValType::F32]);
+        assert_eq!(stack[0], ValType::I32);
+        assert_eq!(stack[1], ValType::I64);
+        assert_eq!(stack[2], ValType::F32);
+        assert_eq!(stack.slot_height(), 4);
+        assert_eq!(stack.slot_depth(1), 1);
+        assert_eq!(stack.slot_depth(2), 3);
+        assert_eq!(stack.slot_depth(3), 4);
+        // a depth beyond the stack is clamped to the whole stack
+        assert_eq!(stack.slot_depth(10), 4);
+    }
+}

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -11,11 +11,19 @@ pub use store::*;
 pub use syscall_handler::*;
 pub use types::*;
 
+/// Compiles `wasm_binary` once per available strategy and runs `f` on each definition, in the
+/// order rwasm, then Wasmtime (when the feature is enabled).
+///
+/// The config must be strategy compatible (see
+/// [`CompilationConfig::default_strategy_compatible`]); otherwise the strategies would charge
+/// different fuel for the same module and the comparison would be meaningless, so such a config
+/// is rejected with [`crate::CompilationError::StrategyIncompatibleConfig`].
 pub fn for_each_strategy<R, F: FnMut(StrategyDefinition) -> Result<R, StrategyError>>(
     mut f: F,
     compilation_config: CompilationConfig,
     wasm_binary: &[u8],
 ) -> Result<Vec<R>, StrategyError> {
+    StrategyDefinition::ensure_strategy_compatible(&compilation_config)?;
     let mut result = Vec::new();
     // rwasm case
     {

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -29,8 +29,7 @@ pub fn for_each_strategy<R, F: FnMut(StrategyDefinition) -> Result<R, StrategyEr
     #[cfg(feature = "wasmtime")]
     {
         let module =
-            crate::wasmtime::compile_wasmtime_module(compilation_config.clone(), wasm_binary)
-                .unwrap();
+            crate::wasmtime::compile_wasmtime_module(compilation_config.clone(), wasm_binary)?;
         result.push(f(StrategyDefinition::Wasmtime { module })?);
     }
     Ok(result)

--- a/src/strategy/module.rs
+++ b/src/strategy/module.rs
@@ -269,6 +269,10 @@ impl<T: 'static> StrategyExecutor<T> {
         }
     }
 
+    /// Resumes an execution interrupted with [`TrapCode::InterruptionCalled`].
+    ///
+    /// Fails with [`TrapCode::IllegalOpcode`] when there is nothing to resume (no interruption
+    /// happened, or the Wasmtime strategy, which does not support interruptions).
     pub fn resume(
         &mut self,
         interruption_result: &[Value],

--- a/src/strategy/module.rs
+++ b/src/strategy/module.rs
@@ -116,7 +116,7 @@ impl StrategyDefinition {
                     syscall_handler,
                     fuel_limit,
                     max_allowed_memory_pages,
-                );
+                )?;
                 Ok(StrategyExecutor::Wasmtime { executor })
             }
         }

--- a/src/strategy/module.rs
+++ b/src/strategy/module.rs
@@ -86,7 +86,9 @@ impl StrategyDefinition {
         wasm_binary: impl AsRef<[u8]>,
         module_caching_key: Option<[u8; 32]>,
     ) -> Result<Self, CompilationError> {
-        use crate::wasmtime::{compile_wasmtime_module, compile_wasmtime_module_cached_with};
+        use crate::wasmtime::{
+            compile_wasmtime_module, compile_wasmtime_module_cached_with, CachePolicy,
+        };
         Self::ensure_strategy_compatible(&compilation_config)?;
         let wasm_binary = wasm_binary.as_ref();
         let compile = |config: CompilationConfig| -> Result<_, CompilationError> {
@@ -97,6 +99,7 @@ impl StrategyDefinition {
             Some(module_caching_key) => compile_wasmtime_module_cached_with(
                 compilation_config,
                 module_caching_key,
+                CachePolicy::RwasmValidated,
                 compile,
             )?,
             None => compile(compilation_config)?,

--- a/src/strategy/module.rs
+++ b/src/strategy/module.rs
@@ -50,29 +50,35 @@ impl StrategyDefinition {
 
     /// Compiles a wasm binary for the Wasmtime strategy.
     ///
-    /// # Panics
+    /// The binary is first run through the rwasm front end ([`RwasmModule::compile`]) and only
+    /// then handed to Wasmtime. Wasmtime accepts a superset of the rwasm language, so without
+    /// that step the two strategies would disagree on which modules compile at all: rwasm
+    /// enforces the memory and table caps, the start-section and import rules and the accepted
+    /// proposal set, and Wasmtime does not. A module that rwasm rejects is rejected here with the
+    /// same error, and a Wasmtime failure is reported as
+    /// [`CompilationError::WasmtimeCompilationFailed`] instead of a panic.
     ///
-    /// Panics if Wasmtime rejects the binary. This is deliberate fail-fast on API misuse rather
-    /// than a recoverable error: the caller is expected to have run this crate's own
-    /// validation/compilation rules over the binary first (rwasm accepts a strict subset of what
-    /// Wasmtime accepts), so a binary that reaches this point and still fails to compile means the
-    /// caller skipped validation, and we'd rather crash loudly than let unvalidated input flow
-    /// further. Feed untrusted wasm through the rwasm validation path before calling this.
+    /// With a `module_caching_key` the validation runs only on a cache miss.
     #[cfg(feature = "wasmtime")]
     pub fn new_as_wasmtime(
         compilation_config: CompilationConfig,
         wasm_binary: impl AsRef<[u8]>,
         module_caching_key: Option<[u8; 32]>,
     ) -> Result<Self, CompilationError> {
-        use crate::wasmtime::{compile_wasmtime_module, compile_wasmtime_module_cached};
-        let module = if let Some(binary_caching_key) = module_caching_key {
-            compile_wasmtime_module_cached(compilation_config, wasm_binary, binary_caching_key)
-        } else {
-            compile_wasmtime_module(compilation_config, wasm_binary)
+        use crate::wasmtime::{compile_wasmtime_module, compile_wasmtime_module_cached_with};
+        let wasm_binary = wasm_binary.as_ref();
+        let compile = |config: CompilationConfig| -> Result<_, CompilationError> {
+            RwasmModule::compile(config.clone(), wasm_binary)?;
+            compile_wasmtime_module(config, wasm_binary)
         };
-        let module = module.expect(
-            "rwasm: compilation of wasmtime module can't fail since it's followed by rwasm validation rules, or it's a bug (the binary follows rwasm rules?)",
-        );
+        let module = match module_caching_key {
+            Some(module_caching_key) => compile_wasmtime_module_cached_with(
+                compilation_config,
+                module_caching_key,
+                compile,
+            )?,
+            None => compile(compilation_config)?,
+        };
         Ok(Self::Wasmtime { module })
     }
 

--- a/src/strategy/module.rs
+++ b/src/strategy/module.rs
@@ -134,8 +134,7 @@ impl StrategyDefinition {
                     fuel_limit,
                     max_allowed_memory_pages,
                 );
-                let instance =
-                    import_linker.instantiate(&mut store, engine.clone(), module.clone())?;
+                let instance = import_linker.instantiate(&mut store, *engine, module.clone())?;
                 Ok(StrategyExecutor::Rwasm { store, instance })
             }
             #[cfg(feature = "wasmtime")]

--- a/src/strategy/module.rs
+++ b/src/strategy/module.rs
@@ -22,19 +22,36 @@ impl StrategyDefinition {
     /// Compiles a wasm binary with whichever strategy the crate was built with (Wasmtime when the
     /// `wasmtime` feature is on, the rwasm VM otherwise).
     ///
-    /// Because the strategy is a build-time choice, pass a config whose fuel semantics don't
-    /// depend on it — [`CompilationConfig::default_strategy_compatible`] — rather than
-    /// [`CompilationConfig::default`], which enables rwasm-only fuel injections that the Wasmtime
-    /// path silently ignores.
+    /// Because the strategy is a build-time choice, the config's fuel semantics must not depend
+    /// on it: a config that enables the rwasm-only fuel injections (the plain
+    /// [`CompilationConfig::default`]) is rejected with
+    /// [`CompilationError::StrategyIncompatibleConfig`] regardless of the feature set, so a
+    /// module never silently burns different fuel on the two strategies. Use
+    /// [`CompilationConfig::default_strategy_compatible`].
     pub fn new(
         compilation_config: CompilationConfig,
         wasm_binary: impl AsRef<[u8]>,
         #[allow(unused_variables)] module_caching_key: Option<[u8; 32]>,
     ) -> Result<Self, CompilationError> {
+        Self::ensure_strategy_compatible(&compilation_config)?;
         #[cfg(feature = "wasmtime")]
         return Self::new_as_wasmtime(compilation_config, wasm_binary, module_caching_key);
         #[cfg(not(feature = "wasmtime"))]
         return Self::new_as_rwasm(compilation_config, wasm_binary);
+    }
+
+    /// Rejects a config whose fuel accounting depends on the strategy.
+    ///
+    /// `is_strategy_compatible` used to be advisory only, so a divergent `default()` config was
+    /// accepted and the rwasm-only injections were silently dropped on the Wasmtime strategy.
+    pub(crate) fn ensure_strategy_compatible(
+        compilation_config: &CompilationConfig,
+    ) -> Result<(), CompilationError> {
+        if compilation_config.is_strategy_compatible() {
+            Ok(())
+        } else {
+            Err(CompilationError::StrategyIncompatibleConfig)
+        }
     }
 
     pub fn new_as_rwasm(
@@ -59,6 +76,10 @@ impl StrategyDefinition {
     /// [`CompilationError::WasmtimeCompilationFailed`] instead of a panic.
     ///
     /// With a `module_caching_key` the validation runs only on a cache miss.
+    ///
+    /// The Wasmtime engine does not implement `consume_fuel_for_bulk_ops` or
+    /// `consume_fuel_for_params_and_locals`, so a config enabling either is rejected with
+    /// [`CompilationError::StrategyIncompatibleConfig`] rather than silently under-metered.
     #[cfg(feature = "wasmtime")]
     pub fn new_as_wasmtime(
         compilation_config: CompilationConfig,
@@ -66,6 +87,7 @@ impl StrategyDefinition {
         module_caching_key: Option<[u8; 32]>,
     ) -> Result<Self, CompilationError> {
         use crate::wasmtime::{compile_wasmtime_module, compile_wasmtime_module_cached_with};
+        Self::ensure_strategy_compatible(&compilation_config)?;
         let wasm_binary = wasm_binary.as_ref();
         let compile = |config: CompilationConfig| -> Result<_, CompilationError> {
             RwasmModule::compile(config.clone(), wasm_binary)?;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -97,6 +97,11 @@ pub const N_MAX_TABLES: u32 = 100;
 /// The original standard allows `100_000` element segments with an unlimited number of elements
 /// inside.
 ///
+/// Both strategies enforce the cap: the compiler rejects a table declared larger than this
+/// (`SegmentBuilder::emit_table_segment` and the Wasmtime compile path), the rwasm VM fails any
+/// `table.grow` beyond it (`TableEntity::grow_untyped`), and the Wasmtime store applies it as its
+/// `table_elements` limit.
+///
 /// # Safety
 ///
 /// The same caveat as for [`N_MAX_ALLOWED_MEMORY_PAGES`] applies: the injected prologues for

--- a/src/types/untyped_value.rs
+++ b/src/types/untyped_value.rs
@@ -8,15 +8,22 @@ use core::{
     ops::{Neg, Shl, Shr},
 };
 
-/// An untyped value.
+/// An untyped value: one 32-bit slot of the rwasm value stack.
 ///
-/// Provides a dense and simple interface to all functional Wasm operations.
+/// Provides a dense and simple interface to all functional Wasm operations on 32-bit values.
+///
+/// rwasm is a 32-bit word machine. An `i64` or `f64` occupies two slots (see
+/// [`crate::I64ValueSplit`]), so this type never holds a 64-bit value on its own. There is
+/// deliberately no `From<u64>` or `From<usize>`: a conversion that silently kept the low limb of a
+/// 64-bit value would be a consensus-critical truncation. The `From<i64>`, `From<f64>` and
+/// `From<F64>` impls do keep only the low 32 bits; they serve the legacy single-limb helpers and
+/// call sites that carry a 32-bit value inside a wider integer, and a caller must never hand them
+/// a value that does not fit.
 #[derive(Debug, Copy, Clone, Default, Hash, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct UntypedValue {
-    /// This inner value is required to have enough bits to represent
-    /// all fundamental WebAssembly types `i32`, `i64`, `f32` and `f64`.
+    /// The 32 bits of the slot; `i32`/`f32` values in full, one limb of an `i64`/`f64`.
     bits: u32,
 }
 
@@ -83,26 +90,6 @@ macro_rules! impl_from_unsigned_prim {
 impl_from_unsigned_prim!(
     bool, u8, u16, u32,
 );
-
-impl From<u64> for UntypedValue {
-    fn from(value: u64) -> Self {
-        debug_assert!(
-            value <= u32::MAX as u64,
-            "u64 value does not fit into UntypedValue"
-        );
-        Self { bits: value as _ }
-    }
-}
-
-impl From<usize> for UntypedValue {
-    fn from(value: usize) -> Self {
-        debug_assert!(
-            value <= u32::MAX as usize,
-            "usize value does not fit into UntypedValue"
-        );
-        Self { bits: value as _ }
-    }
-}
 
 macro_rules! impl_from_signed_prim {
     ( $( $prim:ty as $base:ty ),* $(,)? ) => {
@@ -980,14 +967,6 @@ impl UntypedValue {
 }
 
 impl UntypedValue {
-    pub fn as_u16(self) -> u16 {
-        debug_assert!(
-            self.bits <= u16::MAX as u32,
-            "UntypedValue does not fit into u16"
-        );
-        u16::from(self)
-    }
-
     pub fn as_u32(self) -> u32 {
         u32::from(self)
     }

--- a/src/vm/engine.rs
+++ b/src/vm/engine.rs
@@ -86,7 +86,14 @@ impl ExecutionEngine {
         }
     }
 
-    /// Resumes the execution of a WASM (WebAssembly) function that was previously interrupted.
+    /// Resumes an execution on `store` that returned [`TrapCode::InterruptionCalled`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TrapCode::IllegalOpcode`] when the store holds no interrupted execution: the
+    /// host called `resume` without a preceding interruption, or a second time after the resumed
+    /// execution finished. That is a host bug, but one a node cannot rule out from the outside,
+    /// so it is reported instead of aborting the process.
     #[inline(always)]
     pub fn resume<T>(
         &self,
@@ -99,9 +106,7 @@ impl ExecutionEngine {
             mut call_stack,
             ip,
             mut value_stack,
-        } = take(&mut store.resumable_context).unwrap_or_else(|| {
-            unreachable!("resume calling without a remaining call stack");
-        });
+        } = take(&mut store.resumable_context).ok_or(TrapCode::IllegalOpcode)?;
         let sp = value_stack.stack_ptr();
         let mut executor =
             RwasmExecutor::new(&module, &mut value_stack, sp, &mut call_stack, ip, store);

--- a/src/vm/engine.rs
+++ b/src/vm/engine.rs
@@ -2,64 +2,38 @@ use crate::{
     CallStack, InstructionPtr, ReusableContext, RwasmExecutor, RwasmModule, RwasmStore, TrapCode,
     Value, ValueStack,
 };
-use alloc::sync::Arc;
 use core::mem::take;
-use spin::Mutex;
 
-/// Represents the core execution engine for managing the execution of a program,
-/// including the handling of values and function calls.
-#[derive(Default, Clone)]
-pub struct ExecutionEngine {
-    inner: Arc<Mutex<ExecutionEngineInner>>,
-}
+/// Runs rwasm modules against an [`RwasmStore`].
+///
+/// The engine holds no state of its own: every call allocates its value and call stacks and hands
+/// them to a fresh executor, and an interrupted execution parks them in the store's resumable
+/// context. It therefore needs no synchronization and is safe to use re-entrantly, e.g. from a
+/// syscall handler that runs another module on [`ExecutionEngine::acquire_shared`] while an
+/// execution on the same engine is in progress.
+///
+/// An earlier version wrapped an empty inner struct in a spin lock. The lock protected nothing,
+/// serialized every execution in the process, and made such a re-entrant handler busy-spin
+/// forever.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ExecutionEngine;
 
 impl ExecutionEngine {
     pub fn new() -> Self {
-        Self::default()
+        Self
+    }
+
+    /// Returns the process-wide engine.
+    ///
+    /// The engine is stateless, so this is equivalent to [`ExecutionEngine::new`]; it is kept for
+    /// hosts that name their engine once and hand it around.
+    pub fn acquire_shared() -> ExecutionEngine {
+        Self
     }
 
     #[inline(always)]
     pub fn entrypoint<T>(
         &self,
-        store: &mut RwasmStore<T>,
-        module: &RwasmModule,
-    ) -> Result<(), TrapCode> {
-        let mut ctx = self.inner.lock();
-        ctx.entrypoint(store, module)
-    }
-
-    #[inline(always)]
-    pub fn execute<T>(
-        &self,
-        store: &mut RwasmStore<T>,
-        module: &RwasmModule,
-        params: &[Value],
-        result: &mut [Value],
-    ) -> Result<(), TrapCode> {
-        let mut ctx = self.inner.lock();
-        ctx.execute(store, module, params, result)
-    }
-
-    #[inline(always)]
-    pub fn resume<T>(
-        &self,
-        store: &mut RwasmStore<T>,
-        params: &[Value],
-        result: &mut [Value],
-    ) -> Result<(), TrapCode> {
-        let mut ctx = self.inner.lock();
-        ctx.resume(store, params, result)
-    }
-}
-
-#[derive(Default)]
-struct ExecutionEngineInner {
-    // we should store a reusable stack here
-}
-
-impl ExecutionEngineInner {
-    pub(crate) fn entrypoint<T>(
-        &mut self,
         store: &mut RwasmStore<T>,
         module: &RwasmModule,
     ) -> Result<(), TrapCode> {
@@ -82,8 +56,9 @@ impl ExecutionEngineInner {
     }
 
     /// Executes a rWasm module's function with the given parameters and stores the result.
-    pub(crate) fn execute<T>(
-        &mut self,
+    #[inline(always)]
+    pub fn execute<T>(
+        &self,
         store: &mut RwasmStore<T>,
         module: &RwasmModule,
         params: &[Value],
@@ -112,8 +87,9 @@ impl ExecutionEngineInner {
     }
 
     /// Resumes the execution of a WASM (WebAssembly) function that was previously interrupted.
-    pub(crate) fn resume<T>(
-        &mut self,
+    #[inline(always)]
+    pub fn resume<T>(
+        &self,
         store: &mut RwasmStore<T>,
         params: &[Value],
         result: &mut [Value],
@@ -140,7 +116,7 @@ impl ExecutionEngineInner {
     }
 
     fn remember_context<T>(
-        &mut self,
+        &self,
         module: RwasmModule,
         store: &mut RwasmStore<T>,
         value_stack: ValueStack,
@@ -154,12 +130,5 @@ impl ExecutionEngineInner {
             value_stack,
         });
         Err(TrapCode::InterruptionCalled)
-    }
-}
-
-impl ExecutionEngine {
-    pub fn acquire_shared() -> ExecutionEngine {
-        static ENGINE: spin::Once<ExecutionEngine> = spin::Once::new();
-        ENGINE.call_once(ExecutionEngine::default).clone()
     }
 }

--- a/src/vm/executor/memory.rs
+++ b/src/vm/executor/memory.rs
@@ -22,6 +22,16 @@ macro_rules! impl_visit_store {
     }
 }
 
+/// Converts a bulk-memory operand (an offset or a byte count) into a slice index.
+///
+/// Wasm defines these operands as `u32`. Sign-extending them instead made rwasm trap on any
+/// operand with bit 31 set, while Wasmtime addresses the upper half of a memory larger than 2 GiB
+/// with the same operand; the two backends must agree on the trap.
+#[inline(always)]
+fn bulk_operand(value: UntypedValue) -> usize {
+    u32::from(value) as usize
+}
+
 impl<'a, T> RwasmExecutor<'a, T> {
     impl_visit_load! {
         fn visit_i32_load(i32_load);
@@ -70,8 +80,8 @@ impl<'a, T> RwasmExecutor<'a, T> {
     #[inline(always)]
     pub(crate) fn visit_memory_fill(&mut self) -> Result<(), TrapCode> {
         let (d, val, n) = self.sp.pop3();
-        let n = i32::from(n) as usize;
-        let offset = i32::from(d) as usize;
+        let n = bulk_operand(n);
+        let offset = bulk_operand(d);
         let byte = u8::from(val);
         let memory = self
             .store
@@ -92,9 +102,9 @@ impl<'a, T> RwasmExecutor<'a, T> {
     #[inline(always)]
     pub(crate) fn visit_memory_copy(&mut self) -> Result<(), TrapCode> {
         let (d, s, n) = self.sp.pop3();
-        let n = i32::from(n) as usize;
-        let src_offset = i32::from(s) as usize;
-        let dst_offset = i32::from(d) as usize;
+        let n = bulk_operand(n);
+        let src_offset = bulk_operand(s);
+        let dst_offset = bulk_operand(d);
         // these accesses just perform the bound checks required by the Wasm spec.
         let data = self.store.global_memory.data_mut();
         data.get(src_offset..)
@@ -127,9 +137,9 @@ impl<'a, T> RwasmExecutor<'a, T> {
             .copied()
             .unwrap_or(false);
         let (d, s, n) = self.sp.pop3();
-        let n = i32::from(n) as usize;
-        let src_offset = i32::from(s) as usize;
-        let dst_offset = i32::from(d) as usize;
+        let n = bulk_operand(n);
+        let src_offset = bulk_operand(s);
+        let dst_offset = bulk_operand(d);
         let memory = self
             .store
             .global_memory
@@ -165,5 +175,25 @@ impl<'a, T> RwasmExecutor<'a, T> {
         }
         empty_data_segments.set(idx, true);
         self.ip.add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bulk_operands_are_unsigned() {
+        assert_eq!(bulk_operand(UntypedValue::from(0)), 0);
+        assert_eq!(
+            bulk_operand(UntypedValue::from(0x7fff_ffff_u32)),
+            0x7fff_ffff
+        );
+        // bit 31 set: an offset into the upper half of a >2 GiB memory, not a negative number
+        assert_eq!(
+            bulk_operand(UntypedValue::from(0x8000_0000_u32)),
+            0x8000_0000
+        );
+        assert_eq!(bulk_operand(UntypedValue::from(-1_i32)), u32::MAX as usize);
     }
 }

--- a/src/vm/handler.rs
+++ b/src/vm/handler.rs
@@ -1,5 +1,5 @@
 use crate::{types::TrapCode, StoreTr, TypedCaller, Value};
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 
 #[derive(Default)]
 #[allow(dead_code)]
@@ -10,9 +10,32 @@ pub struct SimpleCallContext {
     pub output: Vec<u8>,
 }
 
+/// A reference syscall handler for a minimal host: input/output buffers, a state word and
+/// `keccak256`.
+///
+/// It is also the pattern integrators copy, so it does what a production handler must do: every
+/// guest-supplied offset and length is range-checked before any buffer is allocated
+/// (`memory_read_into_vec` validates against the memory size first), arithmetic on guest values
+/// is checked, and malformed parameters are reported as traps rather than panics.
 #[derive(Default)]
 #[allow(dead_code)]
 struct SimpleCallHandler;
+
+/// Reads parameter `index` as a guest `i32` reinterpreted as an unsigned offset or length.
+///
+/// A missing or mistyped parameter means the guest called the import with a signature the host
+/// did not expect; that is a `BadSignature`, not a panic.
+fn param_u32(params: &[Value], index: usize) -> Result<u32, TrapCode> {
+    params
+        .get(index)
+        .and_then(Value::i32)
+        .map(|value| value as u32)
+        .ok_or(TrapCode::BadSignature)
+}
+
+fn param_usize(params: &[Value], index: usize) -> Result<usize, TrapCode> {
+    param_u32(params, index).map(|value| value as usize)
+}
 
 #[allow(dead_code)]
 impl SimpleCallHandler {
@@ -21,7 +44,10 @@ impl SimpleCallHandler {
         params: &[Value],
         _result: &mut [Value],
     ) -> Result<(), TrapCode> {
-        let exit_code = params[0].i32().unwrap();
+        let exit_code = params
+            .first()
+            .and_then(Value::i32)
+            .ok_or(TrapCode::BadSignature)?;
         caller.data_mut().exit_code = exit_code;
         Err(TrapCode::ExecutionHalted)
     }
@@ -31,7 +57,8 @@ impl SimpleCallHandler {
         _params: &[Value],
         result: &mut [Value],
     ) -> Result<(), TrapCode> {
-        result[0] = Value::I32(caller.data().state as i32);
+        let state = caller.data().state as i32;
+        *result.first_mut().ok_or(TrapCode::BadSignature)? = Value::I32(state);
         Ok(())
     }
 
@@ -40,15 +67,20 @@ impl SimpleCallHandler {
         params: &[Value],
         _result: &mut [Value],
     ) -> Result<(), TrapCode> {
-        let target = params[0].i32().unwrap() as usize;
-        let offset = params[1].i32().unwrap() as usize;
-        let length = params[2].i32().unwrap() as usize;
+        let target = param_usize(params, 0)?;
+        let offset = param_usize(params, 1)?;
+        let length = param_usize(params, 2)?;
         caller.data_mut().exit_code = -2020;
+        // the range is checked on the host buffer before anything is copied; `offset + length`
+        // is guest-controlled and may wrap
+        let end = offset
+            .checked_add(length)
+            .ok_or(TrapCode::MemoryOutOfBounds)?;
         let input = caller
             .data()
             .input
-            .get(offset..(offset + length))
-            .unwrap()
+            .get(offset..end)
+            .ok_or(TrapCode::MemoryOutOfBounds)?
             .to_vec();
         caller.memory_write(target, &input)?;
         Ok(())
@@ -59,7 +91,9 @@ impl SimpleCallHandler {
         _params: &[Value],
         result: &mut [Value],
     ) -> Result<(), TrapCode> {
-        result[0] = Value::I32(caller.data().input.len() as i32);
+        let size =
+            i32::try_from(caller.data().input.len()).map_err(|_| TrapCode::IntegerOverflow)?;
+        *result.first_mut().ok_or(TrapCode::BadSignature)? = Value::I32(size);
         Ok(())
     }
 
@@ -68,10 +102,10 @@ impl SimpleCallHandler {
         params: &[Value],
         _result: &mut [Value],
     ) -> Result<(), TrapCode> {
-        let offset = params[0].i32().unwrap() as usize;
-        let length = params[1].i32().unwrap() as usize;
-        let mut buffer = vec![0u8; length];
-        caller.memory_read(offset, &mut buffer)?;
+        let offset = param_usize(params, 0)?;
+        let length = param_usize(params, 1)?;
+        // validates the range against the memory size before allocating `length` bytes
+        let buffer = caller.memory_read_into_vec(offset, length)?;
         caller.data_mut().output.extend_from_slice(&buffer);
         Ok(())
     }
@@ -82,11 +116,10 @@ impl SimpleCallHandler {
         _result: &mut [Value],
     ) -> Result<(), TrapCode> {
         use tiny_keccak::Hasher;
-        let data_offset = params[0].i32().unwrap() as usize;
-        let data_len = params[1].i32().unwrap() as usize;
-        let output32_offset = params[2].i32().unwrap() as usize;
-        let mut buffer = vec![0u8; data_len];
-        caller.memory_read(data_offset, &mut buffer)?;
+        let data_offset = param_usize(params, 0)?;
+        let data_len = param_usize(params, 1)?;
+        let output32_offset = param_usize(params, 2)?;
+        let buffer = caller.memory_read_into_vec(data_offset, data_len)?;
         let mut hash = tiny_keccak::Keccak::v256();
         hash.update(&buffer);
         let mut output = [0u8; 32];
@@ -110,7 +143,8 @@ pub(crate) fn simple_call_handler_syscall_handler(
         0x0004 => SimpleCallHandler::fn_input_size(caller, params, result),
         0x0005 => SimpleCallHandler::fn_write_output(caller, params, result),
         0x0101 => SimpleCallHandler::fn_keccak256(caller, params, result),
-        _ => unreachable!("rwasm: unknown function ({})", func_idx),
+        // an import the module linked but this host does not implement
+        _ => Err(TrapCode::UnknownExternalFunction),
     }
 }
 

--- a/src/vm/import_linker.rs
+++ b/src/vm/import_linker.rs
@@ -86,6 +86,11 @@ impl ImportLinker {
         RwasmInstance::new(store, engine, module)
     }
 
+    /// Registers an imported function.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a duplicate `import_name` or `sys_func_idx`; see [`ImportLinker::insert_entity`].
     pub fn insert_function(
         &mut self,
         import_name: ImportName,
@@ -106,6 +111,11 @@ impl ImportLinker {
         );
     }
 
+    /// Registers an import that the compiler replaces with an intrinsic.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a duplicate `import_name` or `sys_func_idx`; see [`ImportLinker::insert_entity`].
     pub fn insert_intrinsic(
         &mut self,
         import_name: ImportName,
@@ -133,6 +143,14 @@ impl ImportLinker {
         }
     }
 
+    /// Registers an import entity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `import_name` or `entity.sys_func_idx` is already registered. The linker is the
+    /// host's static description of its own imports, built once at startup from constants, so a
+    /// collision is a host programming error and fails fast there rather than at the first
+    /// module that resolves the ambiguous name. Guest input never reaches this method.
     pub fn insert_entity(&mut self, import_name: ImportName, entity: ImportLinkerEntity) {
         let sys_func_idx = entity.sys_func_idx;
         if self.name_to_entity.contains_key(&import_name) {

--- a/src/vm/instance.rs
+++ b/src/vm/instance.rs
@@ -28,6 +28,8 @@ impl RwasmInstance {
         self.engine.execute(store, &self.module, params, result)
     }
 
+    /// Resumes an interrupted execution; see [`ExecutionEngine::resume`] for the error when the
+    /// store holds none.
     pub fn resume<T>(
         &self,
         store: &mut RwasmStore<T>,

--- a/src/vm/memory.rs
+++ b/src/vm/memory.rs
@@ -14,6 +14,14 @@ pub struct GlobalMemory {
 }
 
 impl GlobalMemory {
+    /// Creates a memory of `initial_pages` that may grow up to `max_allowed_memory_pages`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `initial_pages` exceeds `max_allowed_memory_pages` or the page count does not
+    /// fit the target's address space. Both arguments are chosen by the host (the store always
+    /// starts at zero pages), never by a module, so this is a configuration error caught at
+    /// startup rather than a reachable runtime failure.
     pub fn new(initial_pages: Pages, max_allowed_memory_pages: Pages) -> Self {
         let initial_len = initial_pages
             .to_bytes()

--- a/src/wasmtime/context.rs
+++ b/src/wasmtime/context.rs
@@ -2,7 +2,7 @@ use crate::{
     checked_memory_range_end, CallerTr, StoreTr, SyscallHandler, TrapCode, TypedCaller,
     N_BYTES_PER_MEMORY_PAGE,
 };
-use wasmtime::{AsContext, AsContextMut, StoreLimits};
+use wasmtime::{AsContext, AsContextMut, ResourceLimiter, StoreLimits};
 
 const ENGINE_FUEL_EXPECTED: &str = "wasmtime: fuel metering was enabled at store creation";
 
@@ -54,6 +54,85 @@ pub(crate) fn reset_fuel<T: 'static>(
     }
 }
 
+/// Store limits that remember which resource denied a grow.
+///
+/// Wasmtime reports a denied grow during instantiation as a plain error message. The rwasm
+/// entrypoint prologue traps with `MemoryOutOfBounds`/`TableOutOfBounds` for the same module, so
+/// the recorded resource lets [`crate::wasmtime::WasmtimeExecutor::new`] report the matching trap
+/// instead of a generic error.
+pub struct RecordingStoreLimits {
+    inner: StoreLimits,
+    /// The trap matching the most recently denied grow, if any.
+    denied: Option<TrapCode>,
+}
+
+impl RecordingStoreLimits {
+    pub(crate) fn new(inner: StoreLimits) -> Self {
+        Self {
+            inner,
+            denied: None,
+        }
+    }
+
+    /// Returns the trap of the most recent denied grow since the last [`Self::reset_denied`].
+    pub(crate) fn denied(&self) -> Option<TrapCode> {
+        self.denied
+    }
+
+    /// Forgets any recorded denial, so a following failure is attributed to its own grow.
+    pub(crate) fn reset_denied(&mut self) {
+        self.denied = None;
+    }
+}
+
+impl ResourceLimiter for RecordingStoreLimits {
+    fn memory_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        maximum: Option<usize>,
+    ) -> wasmtime::Result<bool> {
+        let allowed = self.inner.memory_growing(current, desired, maximum)?;
+        if !allowed {
+            self.denied = Some(TrapCode::MemoryOutOfBounds);
+        }
+        Ok(allowed)
+    }
+
+    fn memory_grow_failed(&mut self, error: wasmtime::Error) -> wasmtime::Result<()> {
+        self.inner.memory_grow_failed(error)
+    }
+
+    fn table_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        maximum: Option<usize>,
+    ) -> wasmtime::Result<bool> {
+        let allowed = self.inner.table_growing(current, desired, maximum)?;
+        if !allowed {
+            self.denied = Some(TrapCode::TableOutOfBounds);
+        }
+        Ok(allowed)
+    }
+
+    fn table_grow_failed(&mut self, error: wasmtime::Error) -> wasmtime::Result<()> {
+        self.inner.table_grow_failed(error)
+    }
+
+    fn instances(&self) -> usize {
+        self.inner.instances()
+    }
+
+    fn tables(&self) -> usize {
+        self.inner.tables()
+    }
+
+    fn memories(&self) -> usize {
+        self.inner.memories()
+    }
+}
+
 pub struct WrappedContext<T: 'static> {
     pub(crate) syscall_handler: SyscallHandler<T>,
     /// Soft fuel counter used when the engine does not meter fuel itself.
@@ -71,7 +150,7 @@ pub struct WrappedContext<T: 'static> {
     /// The instance's exported memory, resolved once per instantiation so host calls don't
     /// look it up by name.
     pub(crate) memory: Option<wasmtime::Memory>,
-    pub(crate) resource_limiter: StoreLimits,
+    pub(crate) resource_limiter: RecordingStoreLimits,
     pub(crate) data: T,
 }
 

--- a/src/wasmtime/engine.rs
+++ b/src/wasmtime/engine.rs
@@ -1,18 +1,13 @@
 use crate::{CompilationConfig, N_MAX_STACK_SIZE};
 use rwasm_fuel_policy::SyscallName;
-use std::{collections::HashMap, mem::size_of, sync::OnceLock};
+use std::{collections::HashMap, mem::size_of};
 use wasmtime::{Config, Engine, OptLevel, Strategy};
 
-/// Returns the shared Wasmtime engine instance.
+/// Builds a Wasmtime engine for `compilation_config`.
 ///
-/// The engine is configured once and reused globally.
-/// Fuel metering is disabled (`consume_fuel(false)`) because fuel is accounted
-/// inside `RuntimeContext` and system runtimes are expected to self-manage.
-pub fn wasmtime_shared_engine(compilation_config: &CompilationConfig) -> &'static Engine {
-    static ENGINE: OnceLock<Engine> = OnceLock::new();
-    ENGINE.get_or_init(|| wasmtime_engine(compilation_config))
-}
-
+/// The engine bakes in the config's fuel metering, stack limit and syscall fuel parameters, so an
+/// engine is never shared between configs: each compiled module carries the engine it was built
+/// with, and the module cache keys on the config identity.
 pub fn wasmtime_engine(compilation_config: &CompilationConfig) -> Engine {
     let mut cfg = Config::new();
     cfg.strategy(Strategy::Cranelift);

--- a/src/wasmtime/instance.rs
+++ b/src/wasmtime/instance.rs
@@ -5,7 +5,7 @@ use crate::{
         WrappedContext,
     },
     ImportLinker, SyscallHandler, TrapCode, Value, F32, F64, N_BYTES_PER_MEMORY_PAGE,
-    N_DEFAULT_MAX_MEMORY_PAGES, N_MAX_ALLOWED_MEMORY_PAGES,
+    N_DEFAULT_MAX_MEMORY_PAGES, N_MAX_ALLOWED_MEMORY_PAGES, N_MAX_TABLE_SIZE,
 };
 use smallvec::SmallVec;
 use std::sync::Arc;
@@ -152,9 +152,13 @@ impl<T: 'static> WasmtimeExecutor<T> {
         let memory_size_limit = (memory_pages as usize)
             .checked_mul(N_BYTES_PER_MEMORY_PAGE as usize)
             .expect("wasmtime: memory limit is bounded by N_MAX_ALLOWED_MEMORY_PAGES");
+        // the rwasm VM caps every table at `N_MAX_TABLE_SIZE` elements (`TableEntity::grow_untyped`
+        // fails any grow beyond it); apply the same per-table cap here so `table.grow` reports
+        // the same failures on both strategies
         let resource_limiter = RecordingStoreLimits::new(
             wasmtime::StoreLimitsBuilder::new()
                 .memory_size(memory_size_limit)
+                .table_elements(N_MAX_TABLE_SIZE as usize)
                 .build(),
         );
 

--- a/src/wasmtime/instance.rs
+++ b/src/wasmtime/instance.rs
@@ -416,12 +416,15 @@ impl<T: 'static> WasmtimeExecutor<T> {
         Ok(())
     }
 
+    /// Interruptions are not supported on the Wasmtime strategy, so there is never an execution
+    /// to resume; this always fails with [`TrapCode::IllegalOpcode`], the same error the rwasm
+    /// engine reports for a `resume` without an interrupted execution.
     pub fn resume(
         &mut self,
         interruption_result: &[Value],
         result: &mut [Value],
     ) -> Result<(), TrapCode> {
-        unimplemented!("wasmtime: resume is not implemented yet");
+        Err(TrapCode::IllegalOpcode)
     }
 
     pub fn snapshot_memory(&mut self) -> Result<Vec<u8>, TrapCode> {

--- a/src/wasmtime/instance.rs
+++ b/src/wasmtime/instance.rs
@@ -1,6 +1,9 @@
 use crate::{
     checked_memory_range_end,
-    wasmtime::{types::map_wasmtime_error, wasmtime_import_linker, WrappedContext},
+    wasmtime::{
+        context::RecordingStoreLimits, types::map_wasmtime_error, wasmtime_import_linker,
+        WrappedContext,
+    },
     ImportLinker, SyscallHandler, TrapCode, Value, F32, F64, N_BYTES_PER_MEMORY_PAGE,
     N_DEFAULT_MAX_MEMORY_PAGES, N_MAX_ALLOWED_MEMORY_PAGES,
 };
@@ -99,15 +102,18 @@ impl<T: 'static> WasmtimeExecutor<T> {
 
     /// Creates an executor by instantiating an already-compiled Wasmtime module.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if linking or instantiation fails. This is deliberate fail-fast on API misuse: a
-    /// module produced by this crate's own compile path has already been validated against the
-    /// import linker, and start sections (the one way a valid module can trap during
-    /// instantiation) are rejected by default at compile time. So a failure here means the caller
-    /// paired a module with the wrong import linker or bypassed compilation/validation, and we'd
-    /// rather crash loudly than continue with a half-linked instance. Use [`Self::try_new`] to
-    /// get the error instead.
+    /// Instantiation can fail on input the caller cannot pre-validate, so the failure is reported
+    /// with the trap the rwasm strategy raises for the same module rather than as a panic:
+    ///
+    /// - an import the linker does not provide: [`TrapCode::UnknownExternalFunction`]
+    /// - an initial memory or table larger than the store allows:
+    ///   [`TrapCode::MemoryOutOfBounds`] / [`TrapCode::TableOutOfBounds`]
+    /// - a trapping start function: that function's trap
+    /// - any other Wasmtime error: [`TrapCode::IllegalOpcode`]
+    ///
+    /// Use [`Self::try_new`] to get the underlying Wasmtime error instead.
     pub fn new(
         module: wasmtime::Module,
         import_linker: Arc<ImportLinker>,
@@ -115,7 +121,7 @@ impl<T: 'static> WasmtimeExecutor<T> {
         syscall_handler: SyscallHandler<T>,
         fuel_limit: Option<u64>,
         max_allowed_memory_pages: Option<u32>,
-    ) -> Self {
+    ) -> Result<Self, TrapCode> {
         Self::try_new(
             module,
             import_linker,
@@ -124,11 +130,14 @@ impl<T: 'static> WasmtimeExecutor<T> {
             fuel_limit,
             max_allowed_memory_pages,
         )
-        .unwrap_or_else(|err| panic!("wasmtime: can't instantiate module: {}", err))
+        .map_err(map_wasmtime_error)
     }
 
     /// Creates an executor by instantiating an already-compiled Wasmtime module, returning the
-    /// linking or instantiation error instead of panicking.
+    /// linking or instantiation error itself.
+    ///
+    /// The error carries the [`TrapCode`] described on [`Self::new`] as context, so
+    /// `downcast_ref::<TrapCode>()` recovers it.
     pub fn try_new(
         module: wasmtime::Module,
         import_linker: Arc<ImportLinker>,
@@ -143,9 +152,11 @@ impl<T: 'static> WasmtimeExecutor<T> {
         let memory_size_limit = (memory_pages as usize)
             .checked_mul(N_BYTES_PER_MEMORY_PAGE as usize)
             .expect("wasmtime: memory limit is bounded by N_MAX_ALLOWED_MEMORY_PAGES");
-        let resource_limiter = wasmtime::StoreLimitsBuilder::new()
-            .memory_size(memory_size_limit)
-            .build();
+        let resource_limiter = RecordingStoreLimits::new(
+            wasmtime::StoreLimitsBuilder::new()
+                .memory_size(memory_size_limit)
+                .build(),
+        );
 
         let context = WrappedContext {
             syscall_handler,
@@ -175,8 +186,10 @@ impl<T: 'static> WasmtimeExecutor<T> {
         {
             Self::link_spectest_globals(&mut linker, &mut store);
         }
-        let instance_pre = linker.instantiate_pre(&module)?;
-        let instance = instance_pre.instantiate(store.as_context_mut())?;
+        let instance_pre = linker
+            .instantiate_pre(&module)
+            .map_err(|err| err.context(TrapCode::UnknownExternalFunction))?;
+        let instance = Self::instantiate_in(&instance_pre, &mut store)?;
         let mut executor = Self {
             linker,
             store,
@@ -191,13 +204,46 @@ impl<T: 'static> WasmtimeExecutor<T> {
 
     /// Instantiates `module` in this executor's store with its linker, replacing the current
     /// instance and its cached exports.
+    ///
+    /// Errors carry the same [`TrapCode`] context as [`Self::try_new`].
     pub fn instantiate(&mut self, module: &wasmtime::Module) -> wasmtime::Result<()> {
-        let instance_pre = self.linker.instantiate_pre(module)?;
-        let instance = instance_pre.instantiate(self.store.as_context_mut())?;
+        let instance_pre = self
+            .linker
+            .instantiate_pre(module)
+            .map_err(|err| err.context(TrapCode::UnknownExternalFunction))?;
+        let instance = Self::instantiate_in(&instance_pre, &mut self.store)?;
         self.instance_pre = instance_pre;
         self.instance = instance;
         self.refresh_exports();
         Ok(())
+    }
+
+    /// Instantiates `instance_pre` in `store`.
+    ///
+    /// A failure caused by the store's resource limits is tagged with the trap the rwasm
+    /// entrypoint prologue raises for the same module, so both strategies report an oversized
+    /// initial memory or table identically.
+    fn instantiate_in(
+        instance_pre: &wasmtime::InstancePre<WrappedContext<T>>,
+        store: &mut wasmtime::Store<WrappedContext<T>>,
+    ) -> wasmtime::Result<wasmtime::Instance> {
+        store.data_mut().resource_limiter.reset_denied();
+        match instance_pre.instantiate(store.as_context_mut()) {
+            Ok(instance) => Ok(instance),
+            Err(err) => {
+                // A refused initial memory or table aborts instantiation with a plain error. A
+                // refused `memory.grow`/`table.grow` inside the start function, however, is
+                // reported to the guest as `-1` and execution goes on; if the function then fails
+                // for a reason of its own, the error already carries a trap or a `TrapCode`, and
+                // that reason must win over the handled denial.
+                let already_classified = err.downcast_ref::<wasmtime::Trap>().is_some()
+                    || err.downcast_ref::<TrapCode>().is_some();
+                Err(match store.data().resource_limiter.denied() {
+                    Some(trap_code) if !already_classified => err.context(trap_code),
+                    _ => err,
+                })
+            }
+        }
     }
 
     /// Looks up an exported function in the cached export table.

--- a/src/wasmtime/mod.rs
+++ b/src/wasmtime/mod.rs
@@ -22,6 +22,7 @@ use std::{
     sync::{Mutex, OnceLock},
     time::Instant,
 };
+use wasmparser::{Parser, Payload};
 
 pub type WasmtimeModule = wasmtime::Module;
 pub type WasmtimeLinker<T> = wasmtime::Linker<WrappedContext<T>>;
@@ -40,16 +41,55 @@ pub fn deserialize_wasmtime_module(
     module
 }
 
+/// Applies the rwasm compile-time resource caps to a wasm binary before Wasmtime compiles it.
+///
+/// `RwasmModule::compile` rejects a module whose declared initial memory exceeds
+/// `config.max_allowed_memory_pages`. Wasmtime has no compile-time equivalent: its store limiter
+/// acts at instantiation, against a cap the runtime picks independently of the compiler. Without
+/// this check a deployment whose runtime cap exceeds the compile cap accepts a module on the
+/// Wasmtime strategy that the rwasm strategy rejects at compile time.
+///
+/// Only the section headers up to the code section are read, so this costs a fraction of the
+/// compilation itself.
+fn check_compile_limits(
+    config: &CompilationConfig,
+    wasm_binary: &[u8],
+) -> Result<(), CompilationError> {
+    let mut total_pages: u32 = 0;
+    for payload in Parser::new(0).parse_all(wasm_binary) {
+        match payload? {
+            Payload::MemorySection(section) => {
+                for memory_type in section.into_iter() {
+                    let initial_pages = u32::try_from(memory_type?.initial)
+                        .map_err(|_| CompilationError::MaxReadonlyDataReached)?;
+                    total_pages = total_pages.saturating_add(initial_pages);
+                    // inclusive, like `SegmentBuilder::add_memory_pages`
+                    if total_pages > config.max_allowed_memory_pages {
+                        return Err(CompilationError::MaxReadonlyDataReached);
+                    }
+                }
+            }
+            // every section this check cares about precedes the code section
+            Payload::CodeSectionStart { .. } | Payload::End(_) => break,
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 /// Compiles a wasm binary with the Wasmtime engine configured by `compilation_config`.
 ///
-/// This applies Wasmtime's own validation only. The rwasm strategy accepts a strict subset of
-/// what Wasmtime accepts (see [`crate::RwasmModule::compile`]); callers that need both strategies
-/// to agree on the accepted language go through [`crate::StrategyDefinition::new_as_wasmtime`],
-/// which runs the rwasm front end first.
+/// Beyond Wasmtime's own validation this only enforces the rwasm compile-time resource caps
+/// (see [`check_compile_limits`]). The rwasm strategy accepts a strict subset of what Wasmtime
+/// accepts (see [`crate::RwasmModule::compile`]); callers that need both strategies to agree on
+/// the accepted language go through [`crate::StrategyDefinition::new_as_wasmtime`], which runs
+/// the rwasm front end first.
 pub fn compile_wasmtime_module(
     compilation_config: CompilationConfig,
     wasm_binary: impl AsRef<[u8]>,
 ) -> Result<WasmtimeModule, CompilationError> {
+    let wasm_binary = wasm_binary.as_ref();
+    check_compile_limits(&compilation_config, wasm_binary)?;
     #[cfg(feature = "debug-print")]
     print!("compiling wasmtime module... ");
     let start = Instant::now();

--- a/src/wasmtime/mod.rs
+++ b/src/wasmtime/mod.rs
@@ -14,7 +14,7 @@ pub use self::{
 };
 use crate::{
     wasmtime::{context::WrappedContext, engine::wasmtime_engine},
-    CompilationConfig,
+    CompilationConfig, CompilationError,
 };
 use lru::LruCache;
 use std::{
@@ -40,15 +40,22 @@ pub fn deserialize_wasmtime_module(
     module
 }
 
+/// Compiles a wasm binary with the Wasmtime engine configured by `compilation_config`.
+///
+/// This applies Wasmtime's own validation only. The rwasm strategy accepts a strict subset of
+/// what Wasmtime accepts (see [`crate::RwasmModule::compile`]); callers that need both strategies
+/// to agree on the accepted language go through [`crate::StrategyDefinition::new_as_wasmtime`],
+/// which runs the rwasm front end first.
 pub fn compile_wasmtime_module(
     compilation_config: CompilationConfig,
     wasm_binary: impl AsRef<[u8]>,
-) -> wasmtime::Result<WasmtimeModule> {
+) -> Result<WasmtimeModule, CompilationError> {
     #[cfg(feature = "debug-print")]
     print!("compiling wasmtime module... ");
     let start = Instant::now();
     let engine = wasmtime_engine(&compilation_config);
-    let module = wasmtime::Module::new(&engine, wasm_binary);
+    let module = wasmtime::Module::new(&engine, wasm_binary)
+        .map_err(CompilationError::WasmtimeCompilationFailed);
     #[cfg(feature = "debug-print")]
     println!("{:?}", start.elapsed());
     module
@@ -56,11 +63,26 @@ pub fn compile_wasmtime_module(
 
 const MAX_CACHED_COMPILED_MODULES: usize = 10_000;
 
+/// Like [`compile_wasmtime_module`], but memoizes the compiled module in a process-wide LRU cache
+/// under `module_caching_key`.
 pub fn compile_wasmtime_module_cached(
     compilation_config: CompilationConfig,
     wasm_binary: impl AsRef<[u8]>,
     module_caching_key: [u8; 32],
-) -> wasmtime::Result<WasmtimeModule> {
+) -> Result<WasmtimeModule, CompilationError> {
+    compile_wasmtime_module_cached_with(compilation_config, module_caching_key, |config| {
+        compile_wasmtime_module(config, wasm_binary)
+    })
+}
+
+/// Returns the module cached under `module_caching_key`, or compiles it with `compile` and caches
+/// the result. The cache lock is held across `compile`, so concurrent callers with the same key
+/// compile once.
+pub(crate) fn compile_wasmtime_module_cached_with<E>(
+    compilation_config: CompilationConfig,
+    module_caching_key: [u8; 32],
+    compile: impl FnOnce(CompilationConfig) -> Result<WasmtimeModule, E>,
+) -> Result<WasmtimeModule, E> {
     static COMPILED_MODULES: OnceLock<Mutex<LruCache<[u8; 32], WasmtimeModule>>> = OnceLock::new();
     let compiled_modules = COMPILED_MODULES.get_or_init(|| {
         Mutex::new(LruCache::new(
@@ -72,7 +94,7 @@ pub fn compile_wasmtime_module_cached(
     if let Some(module) = guard.get(&module_caching_key) {
         return Ok(module.clone());
     }
-    let module = compile_wasmtime_module(compilation_config, wasm_binary)?;
+    let module = compile(compilation_config)?;
     guard.push(module_caching_key, module.clone());
     Ok(module)
 }

--- a/src/wasmtime/mod.rs
+++ b/src/wasmtime/mod.rs
@@ -14,7 +14,7 @@ pub use self::{
 };
 use crate::{
     wasmtime::{context::WrappedContext, engine::wasmtime_engine},
-    CompilationConfig, CompilationError,
+    CompilationConfig, CompilationError, N_MAX_TABLE_SIZE,
 };
 use lru::LruCache;
 use std::{
@@ -44,10 +44,11 @@ pub fn deserialize_wasmtime_module(
 /// Applies the rwasm compile-time resource caps to a wasm binary before Wasmtime compiles it.
 ///
 /// `RwasmModule::compile` rejects a module whose declared initial memory exceeds
-/// `config.max_allowed_memory_pages`. Wasmtime has no compile-time equivalent: its store limiter
-/// acts at instantiation, against a cap the runtime picks independently of the compiler. Without
-/// this check a deployment whose runtime cap exceeds the compile cap accepts a module on the
-/// Wasmtime strategy that the rwasm strategy rejects at compile time.
+/// `config.max_allowed_memory_pages` or whose table declares more than [`N_MAX_TABLE_SIZE`]
+/// elements. Wasmtime has no compile-time equivalent: its store limiter acts at instantiation,
+/// against a cap the runtime picks independently of the compiler. Without this check a deployment
+/// whose runtime cap exceeds the compile cap accepts a module on the Wasmtime strategy that the
+/// rwasm strategy rejects at compile time.
 ///
 /// Only the section headers up to the code section are read, so this costs a fraction of the
 /// compilation itself.
@@ -66,6 +67,17 @@ fn check_compile_limits(
                     // inclusive, like `SegmentBuilder::add_memory_pages`
                     if total_pages > config.max_allowed_memory_pages {
                         return Err(CompilationError::MaxReadonlyDataReached);
+                    }
+                }
+            }
+            Payload::TableSection(section) => {
+                for table_type in section.into_iter() {
+                    let size = table_type?.initial;
+                    if size > N_MAX_TABLE_SIZE {
+                        return Err(CompilationError::TableSizeExceedsLimit {
+                            size,
+                            limit: N_MAX_TABLE_SIZE,
+                        });
                     }
                 }
             }

--- a/src/wasmtime/mod.rs
+++ b/src/wasmtime/mod.rs
@@ -126,38 +126,74 @@ pub fn compile_wasmtime_module(
 
 const MAX_CACHED_COMPILED_MODULES: usize = 10_000;
 
-/// Like [`compile_wasmtime_module`], but memoizes the compiled module in a process-wide LRU cache
-/// under `module_caching_key`.
+/// Like [`compile_wasmtime_module`], but memoizes the compiled module in a process-wide LRU cache.
+///
+/// The entry is keyed by `module_caching_key` together with the config's
+/// [`CompilationConfig::codegen_identity`]. A compiled module embeds its engine, and the engine
+/// bakes in the config's fuel schedule, stack limit and syscall fuel parameters, so two callers
+/// sharing a key but not a config get two modules instead of the second silently running on the
+/// first caller's metering.
+///
+/// Entries made here are validated by Wasmtime only and never satisfy a lookup from
+/// [`crate::StrategyDefinition::new_as_wasmtime`], which caches under its own
+/// [`CachePolicy`].
 pub fn compile_wasmtime_module_cached(
     compilation_config: CompilationConfig,
     wasm_binary: impl AsRef<[u8]>,
     module_caching_key: [u8; 32],
 ) -> Result<WasmtimeModule, CompilationError> {
-    compile_wasmtime_module_cached_with(compilation_config, module_caching_key, |config| {
-        compile_wasmtime_module(config, wasm_binary)
-    })
+    compile_wasmtime_module_cached_with(
+        compilation_config,
+        module_caching_key,
+        CachePolicy::WasmtimeOnly,
+        |config| compile_wasmtime_module(config, wasm_binary),
+    )
 }
 
-/// Returns the module cached under `module_caching_key`, or compiles it with `compile` and caches
-/// the result. The cache lock is held across `compile`, so concurrent callers with the same key
-/// compile once.
+/// Which front end validated a cached module.
+///
+/// The policy is part of the cache key: a module that only Wasmtime validated must never be
+/// returned to a caller whose contract includes rwasm validation, or a module rwasm rejects (SIMD,
+/// a start section, a missing entrypoint) could be primed under a key by one caller and then
+/// accepted under the same key by the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum CachePolicy {
+    /// Validated by Wasmtime plus the rwasm compile-time resource caps only.
+    WasmtimeOnly,
+    /// Validated by the full rwasm front end before Wasmtime compiled it.
+    RwasmValidated,
+}
+
+/// The key of a cached module: the validation policy, the caller's key and the identity of the
+/// config it was compiled with.
+type ModuleCacheKey = (CachePolicy, [u8; 32], [u8; 32]);
+
+/// Returns the module cached under `module_caching_key`, `policy` and `compilation_config`, or
+/// compiles it with `compile` and caches the result. The cache lock is held across `compile`, so
+/// concurrent callers with the same key compile once.
 pub(crate) fn compile_wasmtime_module_cached_with<E>(
     compilation_config: CompilationConfig,
     module_caching_key: [u8; 32],
+    policy: CachePolicy,
     compile: impl FnOnce(CompilationConfig) -> Result<WasmtimeModule, E>,
 ) -> Result<WasmtimeModule, E> {
-    static COMPILED_MODULES: OnceLock<Mutex<LruCache<[u8; 32], WasmtimeModule>>> = OnceLock::new();
+    static COMPILED_MODULES: OnceLock<Mutex<LruCache<ModuleCacheKey, WasmtimeModule>>> =
+        OnceLock::new();
     let compiled_modules = COMPILED_MODULES.get_or_init(|| {
         Mutex::new(LruCache::new(
             NonZeroUsize::new(MAX_CACHED_COMPILED_MODULES).unwrap(),
         ))
     });
-    // P.S: We don't check config hash here for performance reasons, assuming it's handled by an external caching key
+    let cache_key = (
+        policy,
+        module_caching_key,
+        compilation_config.codegen_identity(),
+    );
     let mut guard = compiled_modules.lock().unwrap();
-    if let Some(module) = guard.get(&module_caching_key) {
+    if let Some(module) = guard.get(&cache_key) {
         return Ok(module.clone());
     }
     let module = compile(compilation_config)?;
-    guard.push(module_caching_key, module.clone());
+    guard.push(cache_key, module.clone());
     Ok(module)
 }

--- a/src/wasmtime/mod.rs
+++ b/src/wasmtime/mod.rs
@@ -27,7 +27,17 @@ use wasmparser::{Parser, Payload};
 pub type WasmtimeModule = wasmtime::Module;
 pub type WasmtimeLinker<T> = wasmtime::Linker<WrappedContext<T>>;
 
-pub fn deserialize_wasmtime_module(
+/// Loads a module from bytes produced by `wasmtime::Module::serialize` on a compatible build.
+///
+/// # Safety
+///
+/// This is a native-code load, not a parse. `wasmtime::Module::deserialize` trusts
+/// `wasmtime_binary` to be an artifact it produced itself and performs no authentication, so
+/// attacker-influenced bytes are arbitrary code execution rather than a decode error. The caller
+/// must guarantee that the bytes come from a trusted producer and reached this call with their
+/// integrity intact (for example, verified by a keyed MAC that the producer computed), and must
+/// never pass unauthenticated cache contents or any bytes received from a network peer.
+pub unsafe fn deserialize_wasmtime_module(
     compilation_config: CompilationConfig,
     wasmtime_binary: impl AsRef<[u8]>,
 ) -> wasmtime::Result<WasmtimeModule> {
@@ -35,6 +45,7 @@ pub fn deserialize_wasmtime_module(
     print!("parsing wasmtime module... ");
     let start = Instant::now();
     let engine = wasmtime_engine(&compilation_config);
+    // SAFETY: forwarded to the caller, see the function's safety contract.
     let module = unsafe { wasmtime::Module::deserialize(&engine, wasmtime_binary) };
     #[cfg(feature = "debug-print")]
     println!("{:?}", start.elapsed());

--- a/src/wasmtime/tests.rs
+++ b/src/wasmtime/tests.rs
@@ -1033,3 +1033,35 @@ mod instantiation_failures {
         );
     }
 }
+
+/// The Wasmtime store applies rwasm's table cap, so a module that reaches instantiation with an
+/// oversized table (bypassing `compile_wasmtime_module`, e.g. through deserialization) fails with
+/// the trap the rwasm prologue would raise.
+#[test]
+fn test_initial_table_above_the_cap_is_table_out_of_bounds() {
+    use crate::{always_failing_syscall_handler, N_MAX_TABLE_SIZE};
+    let engine = compile_wasmtime_module(
+        CompilationConfig::default(),
+        wat::parse_str("(module)").unwrap(),
+    )
+    .unwrap()
+    .engine()
+    .clone();
+    let wasm = wat::parse_str(format!(
+        r#"(module (table {} funcref) (func (export "main")))"#,
+        N_MAX_TABLE_SIZE + 1
+    ))
+    .unwrap();
+    let module = Module::new(&engine, &wasm).unwrap();
+    let err = WasmtimeExecutor::new(
+        module,
+        Arc::new(ImportLinker::default()),
+        (),
+        always_failing_syscall_handler,
+        None,
+        None,
+    )
+    .err()
+    .expect("instantiation must fail");
+    assert_eq!(err, TrapCode::TableOutOfBounds);
+}

--- a/src/wasmtime/tests.rs
+++ b/src/wasmtime/tests.rs
@@ -85,7 +85,8 @@ fn test_call_with_charging_quadratic_wasmtime() {
         |_caller, _sys_func_idx, _params, _result| -> Result<(), TrapCode> { Ok(()) },
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
 
     wasmtime_worker
         .execute("main_with_quadratic", &[], &mut [])
@@ -107,7 +108,8 @@ fn test_call_with_charging_linear_wasmtime() {
         |_caller, _sys_func_idx, _params, _result| -> Result<(), TrapCode> { Ok(()) },
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
 
     wasmtime_worker.execute("main", &[], &mut []).unwrap();
     assert_eq!(
@@ -126,7 +128,8 @@ fn test_call_with_charging_param_overflow_wasmtime() {
         |_caller, _sys_func_idx, _params, _result| -> Result<(), TrapCode> { Ok(()) },
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
 
     let err = wasmtime_worker
         .execute("main_with_overflow", &[], &mut [])
@@ -148,7 +151,8 @@ fn test_wasmtime_executor_missing_entrypoint_returns_trap() {
         |_caller, _sys_func_idx, _params, _result| -> Result<(), TrapCode> { Ok(()) },
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
 
     let err = wasmtime_worker
         .execute("missing_export", &[], &mut [])
@@ -254,7 +258,8 @@ fn test_wasmtime_caller_missing_memory_returns_trap() {
         read_memory_syscall,
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
 
     assert_eq!(
         wasmtime_worker
@@ -274,7 +279,8 @@ fn test_wasmtime_snapshot_missing_memory_returns_trap() {
         read_memory_syscall,
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
 
     assert_eq!(
         wasmtime_worker.snapshot_memory().unwrap_err(),
@@ -292,7 +298,8 @@ fn test_wasmtime_executor_memory_read_into_vec_checks_bounds_before_allocating()
         read_memory_syscall,
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
 
     assert_eq!(
         wasmtime_worker.memory_read_into_vec(0, 4).unwrap(),
@@ -322,7 +329,8 @@ fn test_wasmtime_caller_memory_read_into_vec_checks_bounds_before_allocating() {
         read_memory_syscall,
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
 
     wasmtime_worker.execute("read_ok", &[], &mut []).unwrap();
     assert_eq!(wasmtime_worker.data(), &[1, 2, 3, 4]);
@@ -374,7 +382,8 @@ fn test_wasmtime_fuel_accessors_use_engine_metering_when_enabled() {
         |_caller, _sys_func_idx, _params, _result| -> Result<(), TrapCode> { Ok(()) },
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
 
     assert_eq!(wasmtime_worker.remaining_fuel(), Some(100_000));
     wasmtime_worker.try_consume_fuel(10).unwrap();
@@ -399,7 +408,8 @@ fn test_wasmtime_fuel_accessors_use_soft_counter_when_engine_metering_is_off() {
         |_caller, _sys_func_idx, _params, _result| -> Result<(), TrapCode> { Ok(()) },
         Some(1_000),
         None,
-    );
+    )
+    .unwrap();
 
     assert!(wasmtime_worker.store.get_fuel().is_err());
     assert_eq!(wasmtime_worker.remaining_fuel(), Some(1_000));
@@ -442,7 +452,8 @@ fn test_wasmtime_executor_exports_follow_the_instance() {
         read_memory_syscall,
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
     wasmtime_worker.execute("read_ok", &[], &mut []).unwrap();
     assert_eq!(wasmtime_worker.data(), &[1, 2, 3, 4]);
 
@@ -554,7 +565,7 @@ fn mix_syscall(
 fn test_wasmtime_numeric_imports_round_trip_through_raw_slots() {
     let (module, import_linker) = get_test_numeric_marshalling_module();
     let mut wasmtime_worker =
-        WasmtimeExecutor::new(module, import_linker, (), mix_syscall, Some(100_000), None);
+        WasmtimeExecutor::new(module, import_linker, (), mix_syscall, Some(100_000), None).unwrap();
 
     let mut result = [Value::I64(0)];
     wasmtime_worker.execute("main", &[], &mut result).unwrap();
@@ -568,7 +579,7 @@ fn test_wasmtime_numeric_imports_round_trip_through_raw_slots() {
 fn test_wasmtime_numeric_exports_marshal_params_and_results() {
     let (module, import_linker) = get_test_numeric_marshalling_module();
     let mut wasmtime_worker =
-        WasmtimeExecutor::new(module, import_linker, (), mix_syscall, Some(100_000), None);
+        WasmtimeExecutor::new(module, import_linker, (), mix_syscall, Some(100_000), None).unwrap();
 
     let mut result = [Value::I32(0)];
     wasmtime_worker
@@ -638,7 +649,8 @@ fn test_wasmtime_raw_import_rejects_mistyped_syscall_results() {
         },
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
 
     let mut result = [Value::I64(0)];
     assert_eq!(
@@ -661,7 +673,8 @@ fn test_wasmtime_raw_import_halt_is_a_controlled_exit() {
         },
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
 
     let mut result = [Value::I64(0)];
     wasmtime_worker.execute("main", &[], &mut result).unwrap();
@@ -698,7 +711,8 @@ fn test_wasmtime_caller_fuel_accessors_use_engine_metering_when_enabled() {
         },
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
 
     wasmtime_worker.execute("main", &[], &mut []).unwrap();
     // Only the instructions after the import call are charged against the reset budget.
@@ -732,7 +746,8 @@ fn test_wasmtime_caller_fuel_accessors_use_soft_counter_when_engine_metering_is_
         },
         Some(1_000),
         None,
-    );
+    )
+    .unwrap();
 
     wasmtime_worker.execute("probe", &[], &mut []).unwrap();
     assert_eq!(wasmtime_worker.remaining_fuel(), Some(7));
@@ -778,7 +793,8 @@ fn test_wasmtime_executor_reports_instantiation_errors() {
         read_memory_syscall,
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
     assert!(wasmtime_worker.instantiate(&unlinked_module).is_err());
     wasmtime_worker.execute("read_ok", &[], &mut []).unwrap();
     assert_eq!(wasmtime_worker.data(), &[1, 2, 3, 4]);
@@ -802,7 +818,8 @@ fn test_wasmtime_caller_writes_guest_memory_through_the_cached_handle() {
         },
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
 
     wasmtime_worker.execute("read_ok", &[], &mut []).unwrap();
     assert_eq!(
@@ -858,7 +875,8 @@ fn test_wasmtime_raw_imports_return_float_results() {
         },
         Some(100_000),
         None,
-    );
+    )
+    .unwrap();
 
     let mut result = [Value::F64(crate::F64::from_bits(0))];
     wasmtime_worker.execute("main", &[], &mut result).unwrap();
@@ -866,4 +884,152 @@ fn test_wasmtime_raw_imports_return_float_results() {
         result[0],
         Value::F64(crate::F64::from_bits((-2.25f64).to_bits()))
     );
+}
+
+/// A module whose instantiation fails must be reported as the trap the rwasm strategy raises for
+/// it, never as a panic: the input reaching `WasmtimeExecutor::new` is not pre-validated against
+/// the import linker or the store limits.
+mod instantiation_failures {
+    use super::*;
+    use crate::always_failing_syscall_handler;
+
+    fn compile(wat: &str, config: CompilationConfig) -> Module {
+        compile_wasmtime_module(config, wat::parse_str(wat).unwrap()).unwrap()
+    }
+
+    fn instantiate(module: Module, max_allowed_memory_pages: Option<u32>) -> Result<(), TrapCode> {
+        WasmtimeExecutor::new(
+            module,
+            Arc::new(ImportLinker::default()),
+            (),
+            always_failing_syscall_handler,
+            None,
+            max_allowed_memory_pages,
+        )
+        .map(|_| ())
+    }
+
+    #[test]
+    fn trapping_start_function_is_its_trap() {
+        let module = compile(
+            r#"(module (func $start unreachable) (start $start) (func (export "main")))"#,
+            CompilationConfig::default().with_allow_start_section(true),
+        );
+        assert_eq!(
+            instantiate(module, None),
+            Err(TrapCode::UnreachableCodeReached)
+        );
+    }
+
+    #[test]
+    fn unresolved_import_is_unknown_external_function() {
+        let module = compile(
+            r#"(module (func (import "host" "missing")) (func (export "main")))"#,
+            CompilationConfig::default(),
+        );
+        assert_eq!(
+            instantiate(module, None),
+            Err(TrapCode::UnknownExternalFunction)
+        );
+    }
+
+    #[test]
+    fn initial_memory_above_the_store_limit_is_memory_out_of_bounds() {
+        let module = compile(
+            r#"(module (memory 2) (func (export "main")))"#,
+            CompilationConfig::default(),
+        );
+        assert_eq!(
+            instantiate(module.clone(), Some(1)),
+            Err(TrapCode::MemoryOutOfBounds)
+        );
+        // the same module instantiates once the store permits its initial memory
+        assert_eq!(instantiate(module, Some(2)), Ok(()));
+    }
+
+    /// A refused grow inside the start function returns `-1` to the guest; a failure the function
+    /// raises afterwards for its own reason must not be relabelled as the denial.
+    #[test]
+    fn handled_grow_denial_does_not_relabel_a_later_trap() {
+        let module = compile(
+            r#"(module
+                (memory 1)
+                (func $start
+                    (drop (memory.grow (i32.const 16)))
+                    unreachable)
+                (start $start)
+                (func (export "main")))"#,
+            CompilationConfig::default().with_allow_start_section(true),
+        );
+        assert_eq!(
+            instantiate(module, Some(1)),
+            Err(TrapCode::UnreachableCodeReached)
+        );
+    }
+
+    #[test]
+    fn handled_grow_denial_does_not_relabel_a_host_error() {
+        let wasm = wat::parse_str(
+            r#"(module
+                (import "host" "fail" (func $fail))
+                (memory 1)
+                (func $start
+                    (drop (memory.grow (i32.const 16)))
+                    call $fail)
+                (start $start)
+                (func (export "main")))"#,
+        )
+        .unwrap();
+        let mut import_linker = ImportLinker::default();
+        import_linker.insert_function(
+            ImportName::new("host", "fail"),
+            0x01,
+            SyscallFuelParams::default(),
+            &[],
+            &[],
+        );
+        let import_linker = Arc::new(import_linker);
+        let module = compile_wasmtime_module(
+            CompilationConfig::default()
+                .with_allow_start_section(true)
+                .with_import_linker(import_linker.clone()),
+            wasm,
+        )
+        .unwrap();
+        let err = WasmtimeExecutor::new(
+            module,
+            import_linker,
+            (),
+            |_caller, _sys_func_idx, _params, _result| -> Result<(), TrapCode> {
+                Err(TrapCode::OutOfFuel)
+            },
+            None,
+            Some(1),
+        )
+        .err()
+        .expect("the start function fails");
+        assert_eq!(err, TrapCode::OutOfFuel);
+    }
+
+    #[test]
+    fn try_new_keeps_the_trap_code_as_error_context() {
+        let module = compile(
+            r#"(module (memory 2) (func (export "main")))"#,
+            CompilationConfig::default(),
+        );
+        let err = WasmtimeExecutor::try_new(
+            module,
+            Arc::new(ImportLinker::default()),
+            (),
+            always_failing_syscall_handler,
+            None,
+            Some(1),
+        )
+        .err()
+        .expect("instantiation must fail");
+        assert_eq!(
+            err.downcast_ref::<TrapCode>(),
+            Some(&TrapCode::MemoryOutOfBounds)
+        );
+    }
 }

--- a/src/wasmtime/tests.rs
+++ b/src/wasmtime/tests.rs
@@ -1065,3 +1065,28 @@ fn test_initial_table_above_the_cap_is_table_out_of_bounds() {
     .expect("instantiation must fail");
     assert_eq!(err, TrapCode::TableOutOfBounds);
 }
+
+/// The module cache keys on the compilation config as well as the caller's key: a module carries
+/// the engine it was compiled with, so a cross-config hit would run on the first caller's fuel
+/// schedule.
+#[test]
+fn test_module_cache_distinguishes_configs_under_one_key() {
+    use crate::wasmtime::compile_wasmtime_module_cached;
+    let wasm = wat::parse_str(r#"(module (func (export "main")))"#).unwrap();
+    let key = [0x5a; 32];
+    let metered = CompilationConfig::default().with_consume_fuel(true);
+    let unmetered = CompilationConfig::default().with_consume_fuel(false);
+    let metered_module = compile_wasmtime_module_cached(metered.clone(), &wasm, key).unwrap();
+    let unmetered_module = compile_wasmtime_module_cached(unmetered, &wasm, key).unwrap();
+    // a store meters fuel only if the module's engine was configured to
+    let fuel_enabled =
+        |module: &Module| wasmtime::Store::new(module.engine(), ()).get_fuel().is_ok();
+    assert!(fuel_enabled(&metered_module));
+    assert!(!fuel_enabled(&unmetered_module));
+    // the same key with the same config is a cache hit
+    let again = compile_wasmtime_module_cached(metered, &wasm, key).unwrap();
+    assert!(wasmtime::Engine::same(
+        metered_module.engine(),
+        again.engine()
+    ));
+}

--- a/tests/const_expr.rs
+++ b/tests/const_expr.rs
@@ -1,0 +1,70 @@
+//! `extended-const` lets a constant expression be an arbitrarily long operator chain. The compiler
+//! must translate such globals and segment offsets without recursing on the operator count, since
+//! compilation runs before any fuel is charged and a native stack overflow aborts the process.
+
+use rwasm::{CompilationConfig, ExecutionEngine, ImportLinker, RwasmModule, RwasmStore, Value};
+
+/// A constant expression `i32.const 0` followed by `operators` times `i32.const 1; i32.add`.
+fn add_chain(operators: usize) -> String {
+    let mut expr = String::from("i32.const 0");
+    for _ in 0..operators {
+        expr.push_str(" i32.const 1 i32.add");
+    }
+    expr
+}
+
+fn run_main_i32(wat: &str) -> i32 {
+    let wasm = wat::parse_str(wat).expect("valid WAT");
+    let config = CompilationConfig::default()
+        .with_entrypoint_name("main".into())
+        .with_allow_malformed_entrypoint_func_type(true);
+    let (module, _) = RwasmModule::compile(config, &wasm).expect("module compiles");
+    let mut store = RwasmStore::<()>::default();
+    let instance = ImportLinker::default()
+        .instantiate(&mut store, ExecutionEngine::new(), module)
+        .unwrap();
+    let mut result = [Value::I32(0)];
+    instance.execute(&mut store, &[], &mut result).unwrap();
+    result[0].i32().unwrap()
+}
+
+#[test]
+fn global_with_a_long_extended_const_chain_compiles() {
+    // tens of thousands of operators overflowed the compiler stack before; go well beyond that
+    const OPERATORS: usize = 200_000;
+    let wat = format!(
+        r#"(module
+            (global $g i32 {chain})
+            (func (export "main") (result i32) global.get $g)
+        )"#,
+        chain = add_chain(OPERATORS)
+    );
+    assert_eq!(run_main_i32(&wat), OPERATORS as i32);
+}
+
+#[test]
+fn segment_offsets_with_long_extended_const_chains_compile() {
+    const OPERATORS: usize = 50_000;
+    let wat = format!(
+        r#"(module
+            (memory 1)
+            (table 2 funcref)
+            (data (offset {chain}) "\2a")
+            (elem (offset {elem_chain}) $one)
+            (func $one (result i32) i32.const 1)
+            (func (export "main") (result i32)
+                i32.const {offset}
+                i32.load8_u
+                i32.const 1
+                table.get 0
+                ref.is_null
+                i32.add
+            )
+        )"#,
+        chain = add_chain(OPERATORS),
+        elem_chain = add_chain(1),
+        offset = OPERATORS,
+    );
+    // the data byte landed at `OPERATORS` and the element landed at index 1 (non-null)
+    assert_eq!(run_main_i32(&wat), 42);
+}

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -1,0 +1,90 @@
+//! The shared engine must be re-entrant: a syscall handler may compile and run another module on
+//! `ExecutionEngine::acquire_shared()` while an execution on that engine is in progress. The
+//! engine used to guard an empty state with a non-reentrant spin lock, so this busy-spun forever.
+
+use rwasm::{
+    CompilationConfig, ExecutionEngine, ImportLinker, ImportName, RwasmModule, RwasmStore,
+    SyscallFuelParams, TrapCode, TypedCaller, ValType, Value,
+};
+use std::{
+    sync::{mpsc, Arc},
+    thread,
+    time::Duration,
+};
+
+const OUTER_WAT: &str = r#"
+    (module
+        (import "host" "nested" (func $nested (result i32)))
+        (func (export "main") (result i32)
+            call $nested
+            i32.const 1
+            i32.add))
+"#;
+
+const INNER_WAT: &str = r#"
+    (module
+        (func (export "main") (result i32)
+            i32.const 21
+            i32.const 2
+            i32.mul))
+"#;
+
+fn config() -> CompilationConfig {
+    CompilationConfig::default()
+        .with_entrypoint_name("main".into())
+        .with_allow_malformed_entrypoint_func_type(true)
+}
+
+fn import_linker() -> Arc<ImportLinker> {
+    let mut linker = ImportLinker::default();
+    linker.insert_function(
+        ImportName::new("host", "nested"),
+        1,
+        SyscallFuelParams::default(),
+        &[],
+        &[ValType::I32],
+    );
+    Arc::new(linker)
+}
+
+/// Runs the inner module on the shared engine from inside the outer module's syscall.
+fn nested_syscall_handler(
+    _caller: &mut TypedCaller<()>,
+    _sys_func_idx: u32,
+    _params: &[Value],
+    result: &mut [Value],
+) -> Result<(), TrapCode> {
+    let wasm = wat::parse_str(INNER_WAT).unwrap();
+    let (module, _) = RwasmModule::compile(config(), &wasm).unwrap();
+    let mut store = RwasmStore::<()>::default();
+    let instance = ImportLinker::default()
+        .instantiate(&mut store, ExecutionEngine::acquire_shared(), module)
+        .unwrap();
+    instance.execute(&mut store, &[], result)
+}
+
+fn run_outer() -> i32 {
+    let linker = import_linker();
+    let wasm = wat::parse_str(OUTER_WAT).unwrap();
+    let (module, _) =
+        RwasmModule::compile(config().with_import_linker(linker.clone()), &wasm).unwrap();
+    let mut store = RwasmStore::new(linker.clone(), (), nested_syscall_handler, None, None);
+    let instance = linker
+        .instantiate(&mut store, ExecutionEngine::acquire_shared(), module)
+        .unwrap();
+    let mut result = [Value::I32(0)];
+    instance.execute(&mut store, &[], &mut result).unwrap();
+    result[0].i32().unwrap()
+}
+
+#[test]
+fn shared_engine_is_reentrant_from_a_syscall_handler() {
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let _ = sender.send(run_outer());
+    });
+    let result = receiver
+        .recv_timeout(Duration::from_secs(60))
+        .expect("nested execution on the shared engine did not finish: deadlock");
+    assert_eq!(result, 43);
+}

--- a/tests/fluentbase.rs
+++ b/tests/fluentbase.rs
@@ -65,7 +65,8 @@ fn test_nitro_verifier_wasmtime() {
         fluentbase_syscall_handler,
         None,
         None,
-    );
+    )
+    .unwrap();
     worker.execute("main", &[], &mut []).unwrap();
 }
 

--- a/tests/fluentbase.rs
+++ b/tests/fluentbase.rs
@@ -75,7 +75,7 @@ fn test_nitro_verifier_wasmtime() {
 fn test_nitro_verifier_strategy() {
     let wasm_binary = include_bytes!("assets/nitro-verifier-stack-ub.wasm");
     let import_linker = create_import_linker();
-    let config = CompilationConfig::default()
+    let config = CompilationConfig::default_strategy_compatible()
         .with_entrypoint_name("main".into())
         .with_allow_malformed_entrypoint_func_type(true)
         .with_import_linker(import_linker.clone());

--- a/tests/fuzz.rs
+++ b/tests/fuzz.rs
@@ -1,10 +1,11 @@
 use rwasm::{
-    always_failing_syscall_handler, for_each_strategy, CompilationConfig, RwasmModule, StoreTr,
-    Value, F64,
+    always_failing_syscall_handler, for_each_strategy, CompilationConfig, CompilationError,
+    RwasmModule, StoreTr, StrategyError, Value, F64, N_MAX_TABLE_SIZE,
 };
 
-fn run_rwasm_vs_wasmtime_fuel_check(wasm_binary: &[u8], params: &[Value], result: &mut [Value]) {
-    let config = CompilationConfig::default()
+/// The compilation config the differential fuzzer runs with.
+fn fuzz_config() -> CompilationConfig {
+    CompilationConfig::default()
         .with_entrypoint_name("".into())
         .with_allow_malformed_entrypoint_func_type(true)
         .with_allow_start_section(true)
@@ -12,7 +13,11 @@ fn run_rwasm_vs_wasmtime_fuel_check(wasm_binary: &[u8], params: &[Value], result
         .with_consume_fuel_for_params_and_locals(false)
         .with_allow_func_ref_function_types(false)
         .with_max_allowed_memory_pages(4096)
-        .with_consume_fuel_for_bulk_ops(false);
+        .with_consume_fuel_for_bulk_ops(false)
+}
+
+fn run_rwasm_vs_wasmtime_fuel_check(wasm_binary: &[u8], params: &[Value], result: &mut [Value]) {
+    let config = fuzz_config();
     let (module, _) = RwasmModule::compile(config.clone(), wasm_binary).unwrap();
     println!("{}", module);
     let fuel_consumed = for_each_strategy(
@@ -94,8 +99,8 @@ fn test_fuel_mismatch_2() {
             r#"
 (module
   (type (;0;) (func))
-  (table (;0;) 2076 funcref)
-  (table (;1;) 2795 264955 externref)
+  (table (;0;) 1000 funcref)
+  (table (;1;) 1000 264955 externref)
   (memory (;0;) 0 65341)
   (global (;0;) i32 i32.const 1487)
   (export "" (func 0))
@@ -205,7 +210,7 @@ fn test_fuel_bad_memory() {
             r#"
 (module
   (type (;0;) (func (param i32 i32 i32 i32 i32 i32 i32 i32)))
-  (table (;0;) 996180 996225 funcref)
+  (table (;0;) 1000 1024 funcref)
   (memory (;0;) 1543)
   (global (;0;) f32 f32.const -0x1.0b58fcp+127 (;=-177682950000000000000000000000000000000;))
   (global (;1;) (mut i32) i32.const 7936)
@@ -262,12 +267,13 @@ fn wasmtime_stack_overflow_behaviour_mismatch() {
     );
 }
 
+/// The fuzzer produced a module whose table declares more than `N_MAX_TABLE_SIZE` elements. The
+/// rwasm VM cannot instantiate such a table, so every compile path rejects the module instead of
+/// the two strategies running with tables of different sizes.
 #[test]
 fn test_rwasm_table_size_fatal() {
-    let mut result = vec![Value::I64(0), Value::I64(0), Value::I32(0)];
-    run_rwasm_vs_wasmtime_fuel_check(
-        &wat::parse_str(
-            r#"
+    let wasm = wat::parse_str(
+        r#"
 (module
   (type (;0;) (func (result externref f64 f32)))
   (type (;1;) (func))
@@ -293,11 +299,29 @@ fn test_rwasm_table_size_fatal() {
   (data (;0;) "\df\db\df\00")
 )
 "#,
+    )
+    .unwrap();
+    let expected = |err: &CompilationError| {
+        matches!(
+            err,
+            CompilationError::TableSizeExceedsLimit {
+                size: 4473,
+                limit: N_MAX_TABLE_SIZE,
+            }
         )
-        .unwrap(),
-        &[],
-        &mut result,
-    );
+    };
+    assert!(expected(
+        &RwasmModule::compile(fuzz_config(), &wasm).expect_err("rwasm rejects the table")
+    ));
+    #[cfg(feature = "wasmtime")]
+    assert!(expected(
+        &rwasm::wasmtime::compile_wasmtime_module(fuzz_config(), &wasm)
+            .expect_err("the Wasmtime compile path rejects the table")
+    ));
+    assert!(matches!(
+        for_each_strategy(|_| Ok(()), fuzz_config(), &wasm),
+        Err(StrategyError::CompilationError(err)) if expected(&err)
+    ));
 }
 
 #[test]

--- a/tests/interruption.rs
+++ b/tests/interruption.rs
@@ -171,9 +171,9 @@ fn test_interrupted_call_rwasm_with_overflow() {
     assert_eq!(err, TrapCode::IntegerOverflow);
 }
 
+/// The rwasm engine resumes an interrupted call. The Wasmtime strategy does not support
+/// interruptions: its executor reports the interruption and refuses to resume.
 #[test]
-// Note: this test can't pass, because we don't support interruptions for wasmtime anymore
-#[ignore]
 fn test_interrupted_call_wasmtime() {
     let wasm_binary = wat::parse_str(
         r#"
@@ -238,10 +238,10 @@ fn test_interrupted_call_wasmtime() {
         .execute("main", &[], &mut result)
         .unwrap_err();
     assert_eq!(err, TrapCode::InterruptionCalled);
-    let err = wasmtime_worker.resume(&[], &mut result).unwrap_err();
-    assert_eq!(err, TrapCode::InterruptionCalled);
-    wasmtime_worker.resume(&[], &mut result).unwrap();
-    assert_eq!(result[0].i32().unwrap(), 123);
+    assert_eq!(
+        wasmtime_worker.resume(&[], &mut result),
+        Err(TrapCode::IllegalOpcode)
+    );
 }
 
 #[test]
@@ -320,4 +320,61 @@ fn test_memory_write_during_interruption() {
         module,
         engine: ExecutionEngine::acquire_shared(),
     });
+}
+
+/// `resume` without an interrupted execution is a host bug, but a reachable one; it must be an
+/// error rather than a panic, before any execution, after a completed one, and after the single
+/// resume an interruption allows.
+#[test]
+fn test_resume_without_interruption_is_an_error() {
+    let module = RwasmModuleBuilder::new(instruction_set! {
+        // entrypoint
+        Return
+        // function
+        Call(0xff)
+        Return
+    })
+    .with_source_pc(1)
+    .build();
+    let mut store = RwasmStore::<()>::new(
+        default_import_linker(),
+        (),
+        interrupting_syscall_handler,
+        None,
+        None,
+    );
+    let engine = ExecutionEngine::new();
+    assert_eq!(
+        engine.resume(&mut store, &[], &mut []),
+        Err(TrapCode::IllegalOpcode)
+    );
+    assert_eq!(
+        engine.execute(&mut store, &module, &[], &mut []),
+        Err(TrapCode::InterruptionCalled)
+    );
+    engine.resume(&mut store, &[], &mut []).unwrap();
+    assert_eq!(
+        engine.resume(&mut store, &[], &mut []),
+        Err(TrapCode::IllegalOpcode)
+    );
+
+    // the Wasmtime strategy does not support interruptions, so it reports the same error
+    let module = compile_wasmtime_module(
+        CompilationConfig::default().with_consume_fuel(false),
+        wat::parse_str(r#"(module (func (export "main")))"#).unwrap(),
+    )
+    .unwrap();
+    let mut wasmtime_worker = WasmtimeExecutor::new(
+        module,
+        default_import_linker(),
+        (),
+        interrupting_syscall_handler,
+        None,
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        wasmtime_worker.resume(&[], &mut []),
+        Err(TrapCode::IllegalOpcode)
+    );
 }

--- a/tests/interruption.rs
+++ b/tests/interruption.rs
@@ -231,7 +231,8 @@ fn test_interrupted_call_wasmtime() {
         interrupting_syscall_handler,
         None,
         None,
-    );
+    )
+    .unwrap();
     let mut result = [Value::I32(0); 1];
     let err = wasmtime_worker
         .execute("main", &[], &mut result)

--- a/tests/locals.rs
+++ b/tests/locals.rs
@@ -66,3 +66,78 @@ fn test_max_number_of_locals() {
     // old locals: 15'728'970 bytes
     // new local: 1'130 bytes
 }
+
+/// Runs `main` of `wat` on the rwasm VM and returns its single `i64` result.
+fn run_main_i64(wat: &str) -> i64 {
+    use rwasm::{ExecutionEngine, ImportLinker, RwasmStore, Value};
+    let wasm = wat::parse_str(wat).expect("valid WAT");
+    let config = CompilationConfig::default()
+        .with_entrypoint_name("main".into())
+        .with_allow_malformed_entrypoint_func_type(true);
+    let (module, _) = RwasmModule::compile(config, &wasm).expect("module compiles");
+    let mut store = RwasmStore::<()>::default();
+    let instance = ImportLinker::default()
+        .instantiate(&mut store, ExecutionEngine::new(), module)
+        .unwrap();
+    let mut result = [Value::I64(0)];
+    instance.execute(&mut store, &[], &mut result).unwrap();
+    result[0].i64().unwrap()
+}
+
+/// Local accesses are lowered to value-stack slot depths, and `i64` locals take two slots. Mixed
+/// local widths, deep operand stacks and every `local.*` opcode must resolve to the right slots;
+/// the compiler computes those depths incrementally rather than by rescanning the type stack.
+#[test]
+fn test_mixed_width_locals_resolve_to_the_right_slots() {
+    const LOCALS: u32 = 300;
+    let mut wat = String::from("(module (func (export \"main\") (result i64)");
+    for i in 0..LOCALS {
+        wat.push_str(if i % 2 == 0 {
+            " (local i32)"
+        } else {
+            " (local i64)"
+        });
+    }
+    // local i := i, going through `local.tee` on odd indices
+    for i in 0..LOCALS {
+        if i % 2 == 0 {
+            wat.push_str(&format!(" i32.const {i} local.set {i}"));
+        } else {
+            wat.push_str(&format!(" i64.const {i} local.tee {i} drop"));
+        }
+    }
+    // sum every local with a deep operand stack: push all, then fold with `i64.add`
+    wat.push_str(" i64.const 0");
+    for i in 0..LOCALS {
+        if i % 2 == 0 {
+            wat.push_str(&format!(" local.get {i} i64.extend_i32_u"));
+        } else {
+            wat.push_str(&format!(" local.get {i}"));
+        }
+    }
+    for _ in 0..LOCALS {
+        wat.push_str(" i64.add");
+    }
+    wat.push_str("))");
+    let expected = (0..LOCALS as i64).sum::<i64>();
+    assert_eq!(run_main_i64(&wat), expected);
+}
+
+/// A body that declares many locals and touches one of them many times compiles in linear time.
+/// The local count stays below the VM's value-stack limit so the module also runs.
+#[test]
+fn test_many_locals_with_many_accesses_compile() {
+    const LOCALS: u32 = 4_000;
+    const ACCESSES: u32 = 40_000;
+    let mut wat = String::from("(module (func (export \"main\") (result i64) (local i64)");
+    for _ in 0..LOCALS - 2 {
+        wat.push_str(" (local i32)");
+    }
+    wat.push_str(" (local i64)");
+    wat.push_str(" i64.const 7 local.set 0");
+    for _ in 0..ACCESSES {
+        wat.push_str(&format!(" local.get 0 local.set {}", LOCALS - 1));
+    }
+    wat.push_str(&format!(" local.get {}))", LOCALS - 1));
+    assert_eq!(run_main_i64(&wat), 7);
+}

--- a/tests/snippets_off.rs
+++ b/tests/snippets_off.rs
@@ -130,7 +130,7 @@ fn execute_main(wat_source: &str, params: &[Value], result: &mut [Value]) {
     let wasm_binary = wat::parse_str(wat_source).unwrap();
     let (rwasm_module, _) = RwasmModule::compile(snippets_off_config(), &wasm_binary).unwrap();
     let mut store = RwasmStore::<()>::default();
-    let engine = ExecutionEngine::default();
+    let engine = ExecutionEngine::new();
     engine
         .execute(&mut store, &rwasm_module, params, result)
         .expect("execution must succeed");

--- a/tests/strategy.rs
+++ b/tests/strategy.rs
@@ -376,3 +376,100 @@ mod accepted_language {
         ));
     }
 }
+
+/// A config enabling the rwasm-only fuel injections charges different fuel on the two strategies,
+/// so the strategy-agnostic constructors reject it instead of silently under-metering on Wasmtime.
+/// The differential check pins that the strategy-compatible default charges identical fuel on the
+/// audit's counter-example (a function with locals doing a large `memory.fill`).
+mod strategy_compatibility {
+    use super::*;
+    use rwasm::{for_each_strategy, CompilationError, StrategyError};
+
+    const FILL_WAT: &str = r#"
+        (module
+            (memory 1)
+            (func (export "main") (result i32)
+                (local i32 i32 i32 i32 i64 i64 f32 f64)
+                i32.const 0
+                i32.const 42
+                i32.const 60000
+                memory.fill
+                local.get 0
+                i64.const 7
+                local.set 4
+                local.get 4
+                i32.wrap_i64
+                i32.add))
+    "#;
+
+    fn incompatible() -> CompilationConfig {
+        CompilationConfig::default()
+            .with_entrypoint_name("main".into())
+            .with_allow_malformed_entrypoint_func_type(true)
+    }
+
+    #[test]
+    fn strategy_agnostic_constructors_reject_incompatible_configs() {
+        let wasm = wat::parse_str(FILL_WAT).unwrap();
+        assert!(!incompatible().is_strategy_compatible());
+        assert!(matches!(
+            StrategyDefinition::new(incompatible(), &wasm, None),
+            Err(CompilationError::StrategyIncompatibleConfig)
+        ));
+        assert!(matches!(
+            StrategyDefinition::new_as_wasmtime(incompatible(), &wasm, Some([3; 32])),
+            Err(CompilationError::StrategyIncompatibleConfig)
+        ));
+        assert!(matches!(
+            for_each_strategy(|_| Ok(()), incompatible(), &wasm),
+            Err(StrategyError::CompilationError(
+                CompilationError::StrategyIncompatibleConfig
+            ))
+        ));
+        // each flag alone is enough to diverge
+        for config in [
+            strategy_config().with_consume_fuel_for_bulk_ops(true),
+            strategy_config().with_consume_fuel_for_params_and_locals(true),
+        ] {
+            assert!(matches!(
+                StrategyDefinition::new(config, &wasm, None),
+                Err(CompilationError::StrategyIncompatibleConfig)
+            ));
+        }
+        // the rwasm VM implements the injections, so the explicit rwasm constructor accepts them
+        StrategyDefinition::new_as_rwasm(incompatible(), &wasm).unwrap();
+        // and the compatible default is accepted everywhere
+        StrategyDefinition::new(strategy_config(), &wasm, None).unwrap();
+    }
+
+    #[test]
+    fn strategy_compatible_default_charges_identical_fuel() {
+        let wasm = wat::parse_str(FILL_WAT).unwrap();
+        let outcomes = for_each_strategy(
+            |strategy| {
+                let mut executor = strategy.create_executor(
+                    Arc::new(ImportLinker::default()),
+                    (),
+                    always_failing_syscall_handler,
+                    Some(1_000_000),
+                    None,
+                )?;
+                let fuel_before = executor.remaining_fuel().unwrap();
+                let mut result = [Value::I32(0)];
+                let trap = executor.execute("main", &[], &mut result).err();
+                let fuel_consumed = fuel_before - executor.remaining_fuel().unwrap();
+                Ok((trap, result[0].clone(), fuel_consumed))
+            },
+            strategy_config(),
+            &wasm,
+        )
+        .unwrap();
+        assert!(outcomes.len() >= 2, "both strategies must run");
+        assert_eq!(outcomes[0].0, None);
+        assert_eq!(outcomes[0].1, Value::I32(7));
+        assert!(outcomes[0].2 > 0);
+        for outcome in &outcomes[1..] {
+            assert_eq!(outcome, &outcomes[0]);
+        }
+    }
+}

--- a/tests/strategy.rs
+++ b/tests/strategy.rs
@@ -365,6 +365,21 @@ mod accepted_language {
         ));
     }
 
+    /// `compile_wasmtime_module_cached` validates with Wasmtime only. A module it primed under a
+    /// key must not satisfy `new_as_wasmtime` under the same key, or the constructor's rwasm
+    /// validation could be skipped.
+    #[test]
+    fn wasmtime_only_cache_entries_do_not_bypass_rwasm_validation() {
+        let start = wat::parse_str(START_WAT).unwrap();
+        let key = [0x42; 32];
+        rwasm::wasmtime::compile_wasmtime_module_cached(strategy_config(), &start, key)
+            .expect("Wasmtime accepts a start section");
+        assert!(matches!(
+            StrategyDefinition::new_as_wasmtime(strategy_config(), &start, Some(key)),
+            Err(CompilationError::StartSectionsAreNotAllowed)
+        ));
+    }
+
     #[test]
     fn for_each_strategy_reports_compile_errors() {
         let result = rwasm::for_each_strategy(|_| Ok(()), strategy_config(), MALFORMED);

--- a/tests/strategy.rs
+++ b/tests/strategy.rs
@@ -267,3 +267,112 @@ fn compiler_emits_constant_and_quadratic_syscall_fuel_blocks() {
 
     RwasmModule::compile(config, &wasm).unwrap();
 }
+
+/// Both strategies must accept exactly the rwasm language and report a rejected binary as an
+/// error. The Wasmtime path used to compile through Wasmtime alone and `expect` the result, so
+/// anything rwasm rejects but Wasmtime accepts slipped through, and anything Wasmtime rejected
+/// panicked.
+mod accepted_language {
+    use super::*;
+    use rwasm::CompilationError;
+
+    /// A valid header followed by garbage.
+    const MALFORMED: &[u8] = b"\0asm\x01\0\0\0\xff\xff\xff\xff";
+
+    /// Wasmtime accepts SIMD; rwasm does not translate it.
+    const SIMD_WAT: &str = r#"
+        (module
+            (func (export "main")
+                (drop (v128.const i32x4 0 0 0 0))))
+    "#;
+
+    const START_WAT: &str = r#"
+        (module
+            (func $start)
+            (start $start)
+            (func (export "main")))
+    "#;
+
+    #[test]
+    fn malformed_binary_is_an_error_on_every_constructor() {
+        assert!(matches!(
+            StrategyDefinition::new_as_rwasm(strategy_config(), MALFORMED),
+            Err(CompilationError::MalformedWasmBinary(_))
+        ));
+        assert!(matches!(
+            StrategyDefinition::new_as_wasmtime(strategy_config(), MALFORMED, None),
+            Err(CompilationError::MalformedWasmBinary(_))
+        ));
+        assert!(matches!(
+            StrategyDefinition::new(strategy_config(), MALFORMED, None),
+            Err(CompilationError::MalformedWasmBinary(_))
+        ));
+        assert!(matches!(
+            StrategyExecutor::compile_and_instantiate(
+                strategy_config(),
+                MALFORMED,
+                None,
+                Arc::new(ImportLinker::default()),
+                (),
+                always_failing_syscall_handler,
+                None,
+            ),
+            Err(rwasm::StrategyError::CompilationError(
+                CompilationError::MalformedWasmBinary(_)
+            ))
+        ));
+    }
+
+    #[test]
+    fn wasmtime_strategy_rejects_what_rwasm_rejects() {
+        let simd = wat::parse_str(SIMD_WAT).unwrap();
+        let rwasm_err = StrategyDefinition::new_as_rwasm(strategy_config(), &simd)
+            .err()
+            .expect("rwasm rejects SIMD");
+        let wasmtime_err = StrategyDefinition::new_as_wasmtime(strategy_config(), &simd, None)
+            .err()
+            .expect("the Wasmtime strategy must reject SIMD too");
+        assert!(
+            matches!(
+                rwasm_err,
+                CompilationError::NotSupportedOpcode
+                    | CompilationError::NotSupportedExtension
+                    | CompilationError::MalformedWasmBinary(_)
+            ),
+            "unexpected error: {rwasm_err:?}"
+        );
+        assert_eq!(format!("{rwasm_err:?}"), format!("{wasmtime_err:?}"));
+
+        let start = wat::parse_str(START_WAT).unwrap();
+        assert!(matches!(
+            StrategyDefinition::new_as_rwasm(strategy_config(), &start),
+            Err(CompilationError::StartSectionsAreNotAllowed)
+        ));
+        assert!(matches!(
+            StrategyDefinition::new_as_wasmtime(strategy_config(), &start, Some([9; 32])),
+            Err(CompilationError::StartSectionsAreNotAllowed)
+        ));
+        // the rejection is not cached under the key
+        assert!(matches!(
+            StrategyDefinition::new_as_wasmtime(strategy_config(), &start, Some([9; 32])),
+            Err(CompilationError::StartSectionsAreNotAllowed)
+        ));
+
+        let missing_entrypoint = wat::parse_str("(module)").unwrap();
+        assert!(matches!(
+            StrategyDefinition::new_as_wasmtime(strategy_config(), &missing_entrypoint, None),
+            Err(CompilationError::MissingEntrypoint)
+        ));
+    }
+
+    #[test]
+    fn for_each_strategy_reports_compile_errors() {
+        let result = rwasm::for_each_strategy(|_| Ok(()), strategy_config(), MALFORMED);
+        assert!(matches!(
+            result,
+            Err(rwasm::StrategyError::CompilationError(
+                CompilationError::MalformedWasmBinary(_)
+            ))
+        ));
+    }
+}

--- a/tests/tables.rs
+++ b/tests/tables.rs
@@ -200,3 +200,104 @@ fn test_grown_table_still_reports_its_size() {
     .unwrap();
     assert_eq!(result[0].i32(), Some(2));
 }
+
+/// Tables are capped at `N_MAX_TABLE_SIZE` elements on both strategies: a larger declaration is a
+/// compile error on every compile path, a declaration at the cap works, and a runtime `table.grow`
+/// past the cap fails identically. Without the compile-time check the rwasm prologue's `table.grow`
+/// silently failed, leaving the rwasm VM with an empty table where Wasmtime had the declared one.
+#[cfg(feature = "wasmtime")]
+mod table_size_cap {
+    use rwasm::{
+        always_failing_syscall_handler, for_each_strategy, wasmtime::compile_wasmtime_module,
+        CompilationConfig, CompilationError, RwasmModule, StrategyDefinition, StrategyError, Value,
+        N_MAX_TABLE_SIZE,
+    };
+
+    fn config() -> CompilationConfig {
+        CompilationConfig::default_strategy_compatible()
+            .with_entrypoint_name("main".into())
+            .with_allow_malformed_entrypoint_func_type(true)
+    }
+
+    fn table_module(initial: u32) -> Vec<u8> {
+        wat::parse_str(format!(
+            r#"(module
+                (table {initial} funcref)
+                (func (export "main") (param i32) (result i32)
+                    local.get 0
+                    i32.eqz
+                    if (result i32)
+                        table.size 0
+                    else
+                        ref.null func
+                        local.get 0
+                        table.grow 0
+                    end))"#
+        ))
+        .unwrap()
+    }
+
+    /// Runs `main(param)` on every strategy and returns the per-strategy results.
+    fn run_on_each_strategy(wasm: &[u8], param: i32) -> Result<Vec<i32>, StrategyError> {
+        for_each_strategy(
+            |strategy| {
+                let mut executor = strategy.create_executor(
+                    Default::default(),
+                    (),
+                    always_failing_syscall_handler,
+                    Some(1_000_000),
+                    None,
+                )?;
+                let mut result = [Value::I32(0)];
+                executor.execute("main", &[Value::I32(param)], &mut result)?;
+                Ok(result[0].i32().unwrap())
+            },
+            config(),
+            wasm,
+        )
+    }
+
+    #[test]
+    fn table_above_the_cap_is_rejected_on_every_compile_path() {
+        let wasm = table_module(N_MAX_TABLE_SIZE + 1);
+        let expected = |err: &CompilationError| {
+            matches!(
+                err,
+                CompilationError::TableSizeExceedsLimit { size, limit }
+                    if *size == N_MAX_TABLE_SIZE + 1 && *limit == N_MAX_TABLE_SIZE
+            )
+        };
+        assert!(expected(
+            &RwasmModule::compile(config(), &wasm).unwrap_err()
+        ));
+        assert!(expected(
+            &compile_wasmtime_module(config(), &wasm).unwrap_err()
+        ));
+        assert!(expected(
+            &StrategyDefinition::new_as_wasmtime(config(), &wasm, None)
+                .err()
+                .expect("the Wasmtime strategy must reject the table")
+        ));
+        assert!(matches!(
+            run_on_each_strategy(&wasm, 0),
+            Err(StrategyError::CompilationError(err)) if expected(&err)
+        ));
+    }
+
+    #[test]
+    fn table_at_the_cap_has_the_declared_size_on_every_strategy() {
+        let sizes = run_on_each_strategy(&table_module(N_MAX_TABLE_SIZE), 0).unwrap();
+        assert!(sizes.len() >= 2, "both strategies must run");
+        assert!(sizes.iter().all(|size| *size == N_MAX_TABLE_SIZE as i32));
+    }
+
+    #[test]
+    fn table_grow_past_the_cap_fails_on_every_strategy() {
+        let wasm = table_module(1000);
+        let room = (N_MAX_TABLE_SIZE - 1000) as i32;
+        let grown = run_on_each_strategy(&wasm, room).unwrap();
+        assert!(grown.iter().all(|old_size| *old_size == 1000));
+        let refused = run_on_each_strategy(&wasm, room + 1).unwrap();
+        assert!(refused.iter().all(|result| *result == -1));
+    }
+}

--- a/tests/unit/vm/handler_tests.rs
+++ b/tests/unit/vm/handler_tests.rs
@@ -85,3 +85,75 @@ fn typed_rwasm_caller_exposes_store_operations_and_accessors() {
     let caller = caller.into_rwasm();
     assert_eq!(caller.data(), &8);
 }
+
+/// Adversarial parameters must trap, never panic or allocate before the range is validated.
+#[test]
+fn simple_call_handler_rejects_adversarial_parameters() {
+    let context = SimpleCallContext {
+        input: b"abcdef".to_vec(),
+        ..Default::default()
+    };
+    let mut store = RwasmStore::new(
+        Arc::new(ImportLinker::default()),
+        context,
+        always_failing_syscall_handler,
+        None,
+        Some(1),
+    );
+    store.global_memory.grow(Pages::new(1).unwrap()).unwrap();
+    let mut caller = TypedCaller::Rwasm(RwasmCaller::new(&mut store));
+    let call = |caller: &mut TypedCaller<SimpleCallContext>, func_idx, params: &[Value]| {
+        simple_call_handler_syscall_handler(caller, func_idx, params, &mut [])
+    };
+
+    // `offset + length` wraps around on the host input buffer
+    let wrap = [Value::I32(0), Value::I32(-1), Value::I32(2)];
+    assert_eq!(
+        call(&mut caller, 0x0003, &wrap),
+        Err(TrapCode::MemoryOutOfBounds)
+    );
+    // the input range is out of bounds
+    let oob = [Value::I32(0), Value::I32(4), Value::I32(3)];
+    assert_eq!(
+        call(&mut caller, 0x0003, &oob),
+        Err(TrapCode::MemoryOutOfBounds)
+    );
+    // a 4 GiB output read is rejected by the range check before any buffer exists
+    let huge = [Value::I32(0), Value::I32(-1)];
+    assert_eq!(
+        call(&mut caller, 0x0005, &huge),
+        Err(TrapCode::MemoryOutOfBounds)
+    );
+    assert!(caller.data().output.is_empty());
+    // the same for the hashed range, and a hash output offset past the end of memory
+    let huge = [Value::I32(0), Value::I32(-1), Value::I32(0)];
+    assert_eq!(
+        call(&mut caller, 0x0101, &huge),
+        Err(TrapCode::MemoryOutOfBounds)
+    );
+    let past_end = [Value::I32(0), Value::I32(4), Value::I32(65535)];
+    assert_eq!(
+        call(&mut caller, 0x0101, &past_end),
+        Err(TrapCode::MemoryOutOfBounds)
+    );
+    // missing or mistyped parameters are a signature error
+    assert_eq!(call(&mut caller, 0x0001, &[]), Err(TrapCode::BadSignature));
+    assert_eq!(
+        call(
+            &mut caller,
+            0x0003,
+            &[Value::I64(0), Value::I64(0), Value::I64(0)]
+        ),
+        Err(TrapCode::BadSignature)
+    );
+    let mut no_result: [Value; 0] = [];
+    assert_eq!(
+        simple_call_handler_syscall_handler(&mut caller, 0x0002, &[], &mut no_result),
+        Err(TrapCode::BadSignature)
+    );
+    // an unknown import index is an unknown external function
+    assert_eq!(
+        call(&mut caller, 0xdead, &[]),
+        Err(TrapCode::UnknownExternalFunction)
+    );
+}

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -215,8 +215,7 @@ fn untyped_value_numeric_operations_cover_public_wasm_helpers() {
         0
     );
 
-    let value = UntypedValue::from(7_u64);
-    assert_eq!(value.as_u16(), 7);
+    let value = UntypedValue::from(7_u32);
     assert_eq!(value.as_usize(), 7);
     assert_eq!(value.as_f64().to_bits(), 7);
     assert_eq!(value.to_string(), "7");

--- a/tests/wasmtime.rs
+++ b/tests/wasmtime.rs
@@ -162,3 +162,51 @@ fn test_instance_reuse() {
         assert_eq!(result[0].i32(), Some(433_494_437));
     }
 }
+
+/// The compile-time memory cap applies to the Wasmtime compile path exactly as it applies to the
+/// rwasm compiler, so a deployment whose runtime memory limit differs from the compile limit
+/// cannot accept a module on one strategy and reject it on the other.
+mod compile_limits {
+    use super::*;
+    use rwasm::{CompilationError, RwasmModule, N_DEFAULT_MAX_MEMORY_PAGES};
+
+    fn module_with_memory(pages: u32) -> Vec<u8> {
+        wat::parse_str(format!(
+            r#"(module (memory {pages}) (func (export "main") (result i32) memory.size))"#
+        ))
+        .unwrap()
+    }
+
+    fn config() -> CompilationConfig {
+        CompilationConfig::default_strategy_compatible()
+            .with_entrypoint_name("main".into())
+            .with_allow_malformed_entrypoint_func_type(true)
+    }
+
+    #[test]
+    fn wasmtime_compile_path_enforces_the_memory_page_cap() {
+        let too_large = module_with_memory(N_DEFAULT_MAX_MEMORY_PAGES + 1);
+        assert!(matches!(
+            RwasmModule::compile(config(), &too_large),
+            Err(CompilationError::MaxReadonlyDataReached)
+        ));
+        assert!(matches!(
+            compile_wasmtime_module(config(), &too_large),
+            Err(CompilationError::MaxReadonlyDataReached)
+        ));
+        assert!(matches!(
+            StrategyDefinition::new_as_wasmtime(config(), &too_large, None),
+            Err(CompilationError::MaxReadonlyDataReached)
+        ));
+
+        // the cap is inclusive on both paths
+        let at_cap = module_with_memory(N_DEFAULT_MAX_MEMORY_PAGES);
+        RwasmModule::compile(config(), &at_cap).unwrap();
+        compile_wasmtime_module(config(), &at_cap).unwrap();
+
+        // and it follows the configured limit, not a constant
+        let relaxed = config().with_max_allowed_memory_pages(N_DEFAULT_MAX_MEMORY_PAGES + 1);
+        RwasmModule::compile(relaxed.clone(), &too_large).unwrap();
+        compile_wasmtime_module(relaxed, &too_large).unwrap();
+    }
+}


### PR DESCRIPTION
Closes every sub-issue of [FLU-1355](https://linear.app/fluentlabs-xyz/issue/FLU-1355/rwasm-audit-2026-09-09) (rWasm audit 2026-09-09), one commit per finding.

## High

| Issue | Commit | Fix |
| --- | --- | --- |
| [FLU-1356](https://linear.app/fluentlabs-xyz/issue/FLU-1356) tables > `N_MAX_TABLE_SIZE` silently miscompile | `fix(compiler): cap declared table sizes at N_MAX_TABLE_SIZE on both strategies` | A table declared larger than 1024 is a compile error (`CompilationError::TableSizeExceedsLimit`) on the rwasm and the Wasmtime compile path; the Wasmtime store gets the same per-table `table_elements` cap so runtime `table.grow` fails identically. The cap is a constant, so the compile-time check is exhaustive and emitted bytecode is unchanged. |
| [FLU-1357](https://linear.app/fluentlabs-xyz/issue/FLU-1357) default config charges different fuel per backend | `fix(strategy): reject strategy-incompatible fuel configs` | `StrategyDefinition::new`, `new_as_wasmtime` and `for_each_strategy` reject a config with `consume_fuel_for_bulk_ops`/`consume_fuel_for_params_and_locals` enabled (`CompilationError::StrategyIncompatibleConfig`); `new_as_rwasm` and `RwasmModule::compile` still accept it. Adds a differential test on the audit's `memory.fill` example asserting equal result, trap and consumed fuel. |
| [FLU-1358](https://linear.app/fluentlabs-xyz/issue/FLU-1358) const-expr nested closures overflow the stack | `fix(compiler): translate constant expressions without recursion` | `CompiledExpr` stores operators in postfix order and evaluates with an explicit operand stack; build, eval and drop are iterative. `CompiledExpr::new` is fallible instead of panicking. Regression tests use 200k-300k operator chains. |
| [FLU-1359](https://linear.app/fluentlabs-xyz/issue/FLU-1359) `get_expressed_depth` makes local accesses O(n²) | `fix(compiler): resolve local slot depths in O(1)` | New `TypeStack` keeps a prefix sum of slot counts next to the operand types; the expressed depth is a subtraction. Fixes the stale `LocalsRegistry` doc. |
| [FLU-1360](https://linear.app/fluentlabs-xyz/issue/FLU-1360) `alloc_func_type` is O(T²) | `fix(compiler): dedup function types with a hash map` | Canonical signature lookup via `HashMap<FuncType, SignatureIdx>`. |
| [FLU-1361](https://linear.app/fluentlabs-xyz/issue/FLU-1361) default `StrategyDefinition::new` panics and skips rwasm validation | `fix(strategy): validate with rwasm before Wasmtime and drop the compile expect` | `new_as_wasmtime` runs `RwasmModule::compile` first (on a cache miss), so both strategies accept the same language; Wasmtime failures surface as `CompilationError::WasmtimeCompilationFailed`. `compile_wasmtime_module{,_cached}` now return `CompilationError`; `for_each_strategy` no longer unwraps. |
| [FLU-1362](https://linear.app/fluentlabs-xyz/issue/FLU-1362) `WasmtimeExecutor::new` panics on instantiation failure | `fix(wasmtime): return an error when instantiation fails` | `new` returns `Result<Self, TrapCode>`: link errors → `UnknownExternalFunction`, a trapping start keeps its trap, a store-limit denial → `MemoryOutOfBounds`/`TableOutOfBounds` via a recording resource limiter. `try_new` carries the same `TrapCode` as error context. |

## Medium

| Issue | Commit | Fix |
| --- | --- | --- |
| [FLU-1363](https://linear.app/fluentlabs-xyz/issue/FLU-1363) `memory.fill/copy/init` sign-extend operands | `fix(vm): treat bulk-memory operands as unsigned` | `u32` conversion for offsets and lengths, matching Wasmtime and the table bulk ops. |
| [FLU-1364](https://linear.app/fluentlabs-xyz/issue/FLU-1364) memory page cap ignored by the Wasmtime compile path | `fix(wasmtime): enforce the compile-time memory page cap before Wasmtime compiles` | `compile_wasmtime_module` scans the memory (and table) section and applies the same inclusive cap as the rwasm compiler. |
| [FLU-1365](https://linear.app/fluentlabs-xyz/issue/FLU-1365) safe `deserialize_wasmtime_module` over a native-code loader | `fix(wasmtime): mark deserialize_wasmtime_module unsafe` | `pub unsafe fn` with a `# Safety` contract. |
| [FLU-1366](https://linear.app/fluentlabs-xyz/issue/FLU-1366) module cache keyed without config | `fix(wasmtime): key the compiled module cache by config identity` | LRU key is `(caller key, codegen_identity())`; the dormant `wasmtime_shared_engine` `OnceLock` is removed. |
| [FLU-1367](https://linear.app/fluentlabs-xyz/issue/FLU-1367) non-reentrant `spin::Mutex` in the shared engine | `fix(vm): drop the engine mutex so the shared engine is re-entrant` | `ExecutionEngine` is a stateless unit struct; `acquire_shared` keeps its signature. Drops the `spin` dependency. A test re-enters the shared engine from a syscall handler (it deadlocked before). |
| [FLU-1368](https://linear.app/fluentlabs-xyz/issue/FLU-1368) reference handler allocates before validating | `fix(vm): validate reference syscall handler inputs before allocating` | Checked parameter access (`BadSignature`), checked range arithmetic, `memory_read_into_vec`, `UnknownExternalFunction` instead of `unreachable!`. |
| [FLU-1369](https://linear.app/fluentlabs-xyz/issue/FLU-1369) panicking public APIs | `fix(vm): report resume without an interruption as an error` | `ExecutionEngine::resume` and `WasmtimeExecutor::resume` return `TrapCode::IllegalOpcode` instead of `unreachable!`/`unimplemented!`. Remaining fail-fast panics are documented on the functions and `docs/security-considerations.md` lists the panic-free entry points. |
| [FLU-1370](https://linear.app/fluentlabs-xyz/issue/FLU-1370) truncating 64-bit `UntypedValue` conversions | `fix(types): remove truncating 64-bit UntypedValue conversions` | Removes `From<u64>`, `From<usize>`, `as_u16`; fixes the doc comment. `From<usize>` had live callers in the segment builder, which now use checked `u32` conversions. |

## API changes

- `WasmtimeExecutor::new` returns `Result<Self, TrapCode>`.
- `compile_wasmtime_module` and `compile_wasmtime_module_cached` return `Result<WasmtimeModule, CompilationError>`.
- `deserialize_wasmtime_module` is `unsafe`.
- `StrategyDefinition::new` / `new_as_wasmtime` / `for_each_strategy` reject strategy-incompatible configs; `RwasmModule::compile` and `new_as_rwasm` are unchanged.
- New `CompilationError` variants: `StrategyIncompatibleConfig`, `TableSizeExceedsLimit`, `WasmtimeCompilationFailed` (`wasmtime` feature).
- `UntypedValue` loses `From<u64>`, `From<usize>`, `as_u16`.
- `ExecutionEngine` is now a `Copy` unit struct; `new`/`acquire_shared`/`execute`/`resume` keep their signatures.

fluentbase's current usage (`StrategyDefinition::new_as_rwasm`, `compile_wasmtime_module_cached(...).map_err(..)`, `WasmtimeExecutor::try_new`, `ExecutionEngine::acquire_shared`) compiles unchanged against these signatures.

## Out of scope, noted for follow-up

- The legacy single-limb `i64_*`/`f64_*` helpers on `UntypedValue` (and `From<i64>`/`From<F64>`, which they depend on) are used only by tests and truncate 64-bit values the same way; removing them is a separate cleanup.
- Three fuzz-regression fixtures declared tables above the 1024 cap; their table sizes were reduced so they still exercise their original regression, and `test_rwasm_table_size_fatal` now asserts the compile-time rejection.

## Verification

Run locally on this branch (macOS, stable 1.93, nightly-2025-09-20 for snippets):

- `cargo test --no-fail-fast` (default features): 334 passed, 0 failed, 4 ignored (the pre-existing manual/ignored tests)
- `cargo test --manifest-path e2e/Cargo.toml --no-fail-fast` (spec testsuite): 92 passed
- `cargo +nightly-2025-09-20 test --manifest-path snippets/Cargo.toml`: 6 passed, 6 ignored
- `cargo test --release --test fluentbase test_nitro_verifier -- --ignored`: 2 passed (including the strategy test switched to `default_strategy_compatible()`)
- `cargo clippy --all-targets --all-features`, the e2e clippy and the nightly snippets clippy: no warnings in changed files
- `cargo check --no-default-features` and `cargo check --no-default-features --features std` (library): clean
- `cargo fmt --check`: every changed hunk is formatted; the remaining diffs are pre-existing lines

Not run: `make build`'s wasm fixture builds (`examples/*`, `cd snippets && make`); nothing in this branch touches them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented panics during compilation, execution, instantiation, and invalid syscall handling by returning errors or trap codes.
  * Enforced consistent memory and table-size limits across execution strategies.
  * Corrected bulk-memory offset handling for large unsigned values.
  * Improved re-entrant execution and resume behavior.

* **Performance**
  * Improved compilation efficiency for function signatures, locals, and large constant expressions.

* **Documentation**
  * Clarified strategy-compatible fuel configurations, panic-free entry points, resource limits, and host configuration behavior.

* **Breaking Changes**
  * Removed legacy `UntypedValue` conversions and helpers.
  * Some compilation and instantiation APIs now return errors instead of panicking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->